### PR TITLE
build: treat warnings as errors (deprecations excepted)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,15 @@
 
 import PackageDescription
 
+// Warnings are errors across the package so correctness diagnostics (e.g. actor
+// isolation) can't slip into a build. Deprecation warnings are kept as warnings:
+// the remaining ones are a ScreenCaptureKit migration in the test harness,
+// tracked separately. (unsafeFlags because tools-version 6.0 predates the
+// .treatAllWarnings/.treatWarning SwiftSettings; fine for a root app package.)
+let warningsAsErrors: [SwiftSetting] = [
+    .unsafeFlags(["-warnings-as-errors", "-Wwarning", "DeprecatedDeclaration"]),
+]
+
 let package = Package(
     name: "mkdn",
     platforms: [
@@ -89,7 +98,8 @@ let package = Package(
                 .copy("Resources/mermaid.min.js"),
                 .copy("Resources/mermaid-template.html"),
                 .copy("Resources/AppIcon.icns"),
-            ]
+            ],
+            swiftSettings: warningsAsErrors
         ),
         .executableTarget(
             name: "mkdn",
@@ -98,12 +108,13 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "mkdnEntry",
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            swiftSettings: [.swiftLanguageMode(.v5)] + warningsAsErrors
         ),
         .testTarget(
             name: "mkdnTests",
             dependencies: ["mkdnLib"],
-            path: "mkdnTests"
+            path: "mkdnTests",
+            swiftSettings: warningsAsErrors
         ),
     ]
 )

--- a/mkdn/Core/Mermaid/MermaidWebView.swift
+++ b/mkdn/Core/Mermaid/MermaidWebView.swift
@@ -83,9 +83,6 @@
         @Binding var intrinsicWidth: CGFloat
         @Binding var renderState: MermaidRenderState
 
-        /// All diagram `WKWebView` instances share a single web content process.
-        private static let sharedProcessPool = WKProcessPool()
-
         // MARK: - NSViewRepresentable
 
         func makeCoordinator() -> Coordinator {
@@ -97,8 +94,6 @@
             container.allowsInteraction = isFocused
 
             let configuration = WKWebViewConfiguration()
-            configuration.processPool = Self.sharedProcessPool
-
             let contentController = WKUserContentController()
             contentController.add(context.coordinator, name: "sizeReport")
             contentController.add(context.coordinator, name: "renderComplete")

--- a/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+Comments.swift
+++ b/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+Comments.swift
@@ -293,7 +293,12 @@
             NSAnimationContext.runAnimationGroup({ context in
                 context.duration = CommentBoxMetrics.fadeDuration
                 host.animator().alphaValue = 0
-            }, completionHandler: { host.removeFromSuperview() })
+            }, completionHandler: {
+                // The completion fires on the main thread (AppKit animation), but
+                // its closure is nonisolated — assert the main actor to call the
+                // @MainActor removeFromSuperview() without hopping.
+                MainActor.assumeIsolated { host.removeFromSuperview() }
+            })
         }
 
         /// Place the box just below the comment (flipping above when it would fall

--- a/mkdn/Platform/iOS/MermaidWebViewiOS.swift
+++ b/mkdn/Platform/iOS/MermaidWebViewiOS.swift
@@ -15,9 +15,6 @@
         @Binding var renderedHeight: CGFloat
         @Binding var renderState: MermaidRenderState
 
-        /// All diagram `WKWebView` instances share a single web content process.
-        private static let sharedProcessPool = WKProcessPool()
-
         // MARK: - UIViewRepresentable
 
         func makeCoordinator() -> Coordinator {
@@ -26,8 +23,6 @@
 
         func makeUIView(context: Context) -> WKWebView {
             let configuration = WKWebViewConfiguration()
-            configuration.processPool = Self.sharedProcessPool
-
             let contentController = WKUserContentController()
             contentController.add(context.coordinator, name: "sizeReport")
             contentController.add(context.coordinator, name: "renderComplete")


### PR DESCRIPTION
## What

Promote warnings to errors across all targets so correctness diagnostics — Swift concurrency / actor isolation, unused values, etc. — can't slip into a build again (the v0.3.0 build shipped with a couple of warnings).

Deprecation warnings are kept as warnings (`-Wwarning DeprecatedDeclaration`): the remaining ones are a ScreenCaptureKit migration in the test harness, tracked separately.

Also fixes the two non-deprecation warnings the v0.3.0 build surfaced:
- comment-overlay dismiss called `@MainActor removeFromSuperview()` from a nonisolated `NSAnimationContext` completion → `MainActor.assumeIsolated` (the completion already runs on the main thread).
- dropped the deprecated `WKProcessPool` shared-pool plumbing (macOS + iOS); WebKit shares a content process by default since macOS 12.

## Notes
- `unsafeFlags` because tools-version 6.0 predates the `.treatAllWarnings`/`.treatWarning` SwiftSettings (Swift 6.1). Fine for a root app package (not consumed as a versioned dependency).
- Verified: full build + 815 tests green; the cold-cache release build (`swift build -c release`) still completes under the new flags (module-cache/clang notes aren't promoted); enforcement confirmed by an injected unused-var probe failing the build.
- Reviewed: `/code-review --fix` (found + fixed the half-done iOS cleanup) + codex (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)