### PR TITLE
fix: code-block backgrounds mispositioned on first paint

### DIFF
--- a/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+CodeBlocks.swift
+++ b/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+CodeBlocks.swift
@@ -107,7 +107,7 @@
             return frames
         }
 
-        private func textRange(
+        func textRange(
             from nsRange: NSRange,
             contentManager: NSTextContentManager
         ) -> NSTextRange? {

--- a/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+CopyButton.swift
+++ b/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView+CopyButton.swift
@@ -108,6 +108,17 @@
                 return
             }
 
+            // Bail without validating while the view is unsized so the first
+            // real sizing pass recomputes.
+            guard bounds.width > 0,
+                  let textContainer,
+                  textContainer.size.width > 0
+            else {
+                cachedBlockRects = []
+                areBlockRectsValid = false
+                return
+            }
+
             let blocks = collectCodeBlocks(from: textStorage)
             guard !blocks.isEmpty else {
                 cachedBlockRects = []
@@ -115,8 +126,25 @@
                 return
             }
 
+            // Enumerating fragments with `.ensuresLayout` only realizes the
+            // visible viewport; blocks outside it come back with TextKit 2's
+            // *estimated* (fractional, accumulating-error) frame positions, so a
+            // code block below the first viewport gets a wrong Y on first paint
+            // and stays mispositioned until a scroll forces real layout. Force
+            // real layout from the document start through the last code block —
+            // every block's Y depends on all preceding layout — so the frames
+            // below are final. (Trailing content can't affect a block rect, so
+            // there's no need to lay out past the last block.)
+            let lastBlockEnd = blocks.map(\.range.upperBound).max() ?? 0
+            if let layoutRange = textRange(
+                from: NSRange(location: 0, length: lastBlockEnd),
+                contentManager: contentManager
+            ) {
+                layoutManager.ensureLayout(for: layoutRange)
+            }
+
             let origin = textContainerOrigin
-            let containerWidth = textContainer?.size.width ?? bounds.width
+            let containerWidth = textContainer.size.width
             let borderInset = Self.borderWidth / 2
 
             cachedBlockRects = blocks.compactMap { block in

--- a/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView.swift
+++ b/mkdn/Features/Viewer/Views/CodeBlockBackgroundTextView.swift
@@ -253,8 +253,10 @@
 
         /// Pre-draw cache refresh: enumerating layout fragments inside
         /// drawBackground forces TextKit 2 layout during the draw pass,
-        /// causing visible flicker on resize. viewWillDraw fires after
-        /// layout has settled but before drawing begins.
+        /// causing visible flicker on resize. viewWillDraw fires before
+        /// drawing begins; the cache refresh forces real layout itself (see
+        /// refreshCachedBlockRects) since viewWillDraw alone does not guarantee
+        /// TextKit 2 has laid out fragments beyond the visible viewport.
         override func viewWillDraw() {
             super.viewWillDraw()
             refreshCachedBlockRects()

--- a/mkdnTests/Unit/Features/CodeBlockBackgroundGeometryTests.swift
+++ b/mkdnTests/Unit/Features/CodeBlockBackgroundGeometryTests.swift
@@ -1,0 +1,78 @@
+#if os(macOS)
+    import AppKit
+    import Testing
+    @testable import mkdnLib
+
+    /// Regression test for the first-paint code-block background bug: a code
+    /// block sitting below the initial viewport was cached at TextKit 2's
+    /// *estimated* (wrong) Y because `.ensuresLayout` during fragment
+    /// enumeration only realizes the visible viewport. `refreshCachedBlockRects`
+    /// must force real layout so a below-fold block's cached rect matches the
+    /// geometry it has once fully laid out.
+    @Suite("CodeBlockBackgroundGeometry")
+    struct CodeBlockBackgroundGeometryTests {
+        /// Tall lead-in content followed by a code block, so the block lands far
+        /// below the test window's viewport and starts out estimated.
+        @MainActor private func belowFoldBlocks() -> [IndexedBlock] {
+            var blocks: [MarkdownBlock] = (0 ..< 60).map { i in
+                .paragraph(text: AttributedString("Filler paragraph number \(i) with enough text to occupy a line."))
+            }
+            blocks.append(.codeBlock(
+                language: "swift",
+                code: "let answer = 42\nprint(answer)\nlet doubled = answer * 2"
+            ))
+            return blocks.enumerated().map { IndexedBlock(index: $0.offset, block: $0.element) }
+        }
+
+        @MainActor private func makeTextView(
+            _ attributed: NSAttributedString
+        ) -> (CodeBlockBackgroundTextView, NSWindow) {
+            let textContainer = NSTextContainer()
+            textContainer.widthTracksTextView = true
+            let layoutManager = NSTextLayoutManager()
+            layoutManager.textContainer = textContainer
+            let contentStorage = NSTextContentStorage()
+            contentStorage.addTextLayoutManager(layoutManager)
+
+            let textView = CodeBlockBackgroundTextView(
+                frame: NSRect(x: 0, y: 0, width: 600, height: 400),
+                textContainer: textContainer
+            )
+            textView.isVerticallyResizable = true
+            textView.textContainerInset = NSSize(width: 32, height: 32)
+
+            let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+            scrollView.documentView = textView
+            let window = NSWindow(
+                contentRect: scrollView.frame,
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = scrollView
+            textView.textStorage?.setAttributedString(attributed)
+            window.layoutIfNeeded()
+            return (textView, window)
+        }
+
+        @Test("Below-fold code block cached geometry matches fully laid-out reference")
+        @MainActor func belowFoldBlockGeometryIsFinalOnFirstPaint() throws {
+            let result = MarkdownTextStorageBuilder.build(blocks: belowFoldBlocks(), theme: .solarizedDark)
+
+            // Cold: the first refresh after the window lays out, before any scroll.
+            let (textView, _) = makeTextView(result.attributedString)
+            textView.refreshCachedBlockRects()
+            let cold = try #require(textView.cachedBlockRects.last?.rect)
+
+            // Reference: force full real layout, then recompute.
+            let layoutManager = try #require(textView.textLayoutManager)
+            layoutManager.ensureLayout(for: layoutManager.documentRange)
+            textView.invalidateCodeBlockCache()
+            textView.refreshCachedBlockRects()
+            let reference = try #require(textView.cachedBlockRects.last?.rect)
+
+            #expect(abs(cold.minY - reference.minY) < 0.5)
+            #expect(abs(cold.height - reference.height) < 0.5)
+        }
+    }
+#endif


### PR DESCRIPTION
## Problem

Code-block background rectangles rendered in the wrong place when a document first opened, snapping correct only after a scroll/hover. Reported for docs whose first code block sits below the initial viewport.

## Root cause

The background rects are computed from TextKit 2 layout-fragment frames cached in `viewWillDraw`. Enumerating fragments with `.ensuresLayout` only realizes the **visible viewport** — blocks outside it come back with TextKit 2's *estimated* frame positions (telltale fractional Y, accumulating error). The cached background was drawn at that estimated Y and stayed wrong until a scroll forced real layout.

## Fix

Force real layout from the document start through the last code block before reading fragment frames (a block's Y depends on all preceding layout; no need to lay out trailing content). Also bail without validating the cache while the view is unsized so the first sizing pass recomputes.

## Verification

- Reproduced deterministically via the test harness: cold-launch with a file whose first code block is below the initial viewport (`mkdn --test-harness <file>` + immediate capture). The warm `load` path and post-render-complete single capture both masked it.
- Confirmed fixed interactively on a complex doc.
- Added `CodeBlockBackgroundGeometryTests` (real `NSWindow`+`NSScrollView` integration test) — verified to **fail without the fix** (cold Y off by ~540pt) and pass with it.
- Full suite: 816 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)