### PR TITLE
test(harness): recreate-view command for cold first-paint repro

### DIFF
--- a/docs/visual-testing-with-mkdn-ctl.md
+++ b/docs/visual-testing-with-mkdn-ctl.md
@@ -26,6 +26,7 @@ scripts/mkdn-ctl theme solarizedLight
 scripts/mkdn-ctl cycle                         # cycle through themes
 scripts/mkdn-ctl info                          # window size, theme, loaded file
 scripts/mkdn-ctl resize 1024 768               # resize window to 1024x768pt
+scripts/mkdn-ctl recreate-view                 # rebuild the preview cold (see below)
 scripts/mkdn-ctl quit                          # close the app
 ```
 
@@ -61,6 +62,43 @@ When verifying visual changes during development:
    ```bash
    scripts/mkdn-ctl quit
    ```
+
+## Cold First-Paint Testing
+
+Some rendering bugs only appear on a document's **cold first paint** — the very
+first `makeNSView` pass, before TextKit 2 has laid out anything below the
+initial viewport. (Example: code-block backgrounds were once cached from
+TextKit 2's *estimated* fragment frames for blocks below the fold, so they
+rendered in the wrong place until a scroll forced real layout.)
+
+The normal `load` command does **not** reproduce these: it swaps content into an
+already-laid-out view (the warm `updateNSView` path, with real fragment frames).
+A plain `capture` also waits on a render-complete signal that fires only after
+the entrance animator has warmed layout.
+
+Two ways to hit the cold path:
+
+1. **Cold launch** — pass the file as a launch argument so the window's first
+   paint *is* the target document, then capture immediately:
+   ```bash
+   .build/debug/mkdn --test-harness path/to/file.md
+   scripts/mkdn-ctl capture /tmp/cold.png       # no load, no scroll, no hover
+   ```
+
+2. **`recreate-view`** — rebuild the preview cold in an already-running session
+   (no relaunch). It changes the preview's SwiftUI identity, forcing a fresh
+   `makeNSView`:
+   ```bash
+   scripts/mkdn-ctl load path/to/file.md
+   scripts/mkdn-ctl recreate-view
+   scripts/mkdn-ctl capture /tmp/cold.png       # no scroll, no hover
+   ```
+
+Use a file whose triggering element sits **below the initial viewport** — that's
+the region TextKit 2 leaves estimated on first paint. `recreate-view` only has
+an effect when a markdown preview is visible (not the welcome/source/plain-text
+views). After capturing, a scroll or window resize forces real layout and the
+bug "snaps" away — so capture before any such interaction.
 
 ## Fixtures
 

--- a/mkdn/App/DocumentState.swift
+++ b/mkdn/App/DocumentState.swift
@@ -44,6 +44,14 @@
         /// Used to disambiguate block IDs across document loads.
         public private(set) var loadGeneration: UInt64 = 0
 
+        // MARK: - View Rebuild Generation
+
+        /// Identity nonce for the markdown preview's NSView. Bumped only by the
+        /// test harness (see ``rebuildDocumentView()``) to force a cold
+        /// `makeNSView`; stays `0` in normal use so production view identity is
+        /// stable.
+        public private(set) var viewRebuildGeneration: UInt64 = 0
+
         // MARK: - View Mode
 
         /// Current display mode: preview-only or side-by-side editing.
@@ -76,6 +84,14 @@
         public init() {}
 
         // MARK: - Methods
+
+        /// Force the markdown preview's `NSViewRepresentable` to be torn down and
+        /// recreated — a fresh `makeNSView` / cold first paint — by changing its
+        /// SwiftUI identity. Used by the test harness to reproduce cold
+        /// first-paint rendering bugs in-session; not called in normal operation.
+        public func rebuildDocumentView() {
+            viewRebuildGeneration &+= 1
+        }
 
         /// Load a file from the given URL.
         public func loadFile(at url: URL) throws {

--- a/mkdn/Core/TestHarness/HarnessCommand.swift
+++ b/mkdn/Core/TestHarness/HarnessCommand.swift
@@ -101,6 +101,12 @@
         /// the captured frame paths.
         case stopQuickCapture
 
+        /// Recreate the markdown preview's NSView from scratch (a fresh
+        /// `makeNSView` / cold first paint) by changing its SwiftUI identity.
+        /// Reproduces cold first-paint rendering bugs in-session without
+        /// relaunching. Only has an effect when a markdown preview is visible.
+        case recreateView
+
         /// Connectivity check. The server responds with `pong`.
         case ping
 

--- a/mkdn/Core/TestHarness/TestHarnessHandler.swift
+++ b/mkdn/Core/TestHarness/TestHarnessHandler.swift
@@ -21,6 +21,8 @@
                 await handleSetTheme(theme)
             case .reloadFile:
                 await handleReloadFile()
+            case .recreateView:
+                await handleRecreateView()
             case .captureWindow, .captureRegion,
                  .startFrameCapture, .stopFrameCapture,
                  .beginFrameCapture, .endFrameCapture:
@@ -93,6 +95,27 @@
             } catch {
                 return .error("Reload failed: \(error.localizedDescription)")
             }
+        }
+
+        /// Forces a cold recreation of the markdown preview's NSView so a
+        /// first-paint rendering bug can be reproduced without relaunching. The
+        /// rebuild only fires `signalRenderComplete` when a markdown preview is
+        /// mounted, so we only await the render then (a source/plain/welcome view
+        /// has no preview to recreate and would otherwise time out).
+        private static func handleRecreateView() async -> HarnessResponse {
+            guard let docState = documentState else {
+                return .error("No document state available")
+            }
+            let hasMarkdownPreview = docState.currentFileURL != nil
+                && docState.fileKind == .markdown
+            let signal = RenderCompletionSignal.shared
+            if hasMarkdownPreview { signal.prepareForRender() }
+            docState.rebuildDocumentView()
+            if hasMarkdownPreview {
+                try? await signal.awaitPreparedRender(timeout: .seconds(5))
+                return .ok(message: "Document view recreated")
+            }
+            return .ok(message: "No markdown preview to recreate")
         }
 
         // MARK: - Mode Commands

--- a/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
+++ b/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
@@ -57,6 +57,11 @@
                 commentSourceMap: textStorageResult.sourceMap,
                 isLoadingGateActive: $docState.isLoadingGateActive
             )
+            // Changing this identity tears down and recreates the text view's
+            // representable (a fresh cold makeNSView), reusing the already-built
+            // attributed content. Bumped only by the test harness to reproduce
+            // cold first-paint bugs; constant in normal use.
+            .id(documentState.viewRebuildGeneration)
             .background(appSettings.theme.colors.background)
             .task(id: documentState.markdownContent) {
                 if isInitialRender {

--- a/mkdnTests/Unit/Support/HarnessCommandTests.swift
+++ b/mkdnTests/Unit/Support/HarnessCommandTests.swift
@@ -77,6 +77,17 @@ struct HarnessCommandTests {
         }
     }
 
+    @Test("recreateView command round-trips through JSON")
+    func recreateViewRoundTrip() throws {
+        let command = HarnessCommand.recreateView
+        let data = try encoder.encode(command)
+        let decoded = try decoder.decode(HarnessCommand.self, from: data)
+        guard case .recreateView = decoded else {
+            Issue.record("Expected .recreateView, got \(decoded)")
+            return
+        }
+    }
+
     @Test("captureWindow command with output path round-trips through JSON")
     func captureWindowWithPathRoundTrip() throws {
         let command = HarnessCommand.captureWindow(outputPath: "/tmp/capture.png")

--- a/scripts/mkdn-ctl
+++ b/scripts/mkdn-ctl
@@ -28,7 +28,8 @@ def main():
     if len(sys.argv) < 2:
         print("Usage: mkdn-ctl <command> [args]")
         print("Commands: ping, load <path>, capture [path], scroll <y>,")
-        print("          theme <name>, cycle, info, resize <w> <h>, quit")
+        print("          theme <name>, cycle, info, resize <w> <h>,")
+        print("          recreate-view, quit")
         sys.exit(1)
 
     sock = os.environ.get("MKDN_SOCK") or find_socket()
@@ -75,6 +76,8 @@ def main():
             x, y, w, h = float(sys.argv[2]), float(sys.argv[3]), float(sys.argv[4]), float(sys.argv[5])
             path = sys.argv[6] if len(sys.argv) > 6 else "/tmp/mkdn-region.png"
             r = send(sock, {"captureRegion": {"region": {"x": x, "y": y, "width": w, "height": h}, "outputPath": os.path.abspath(path)}})
+        elif cmd_name == "recreate-view":
+            r = send(sock, {"recreateView": {}})
         elif cmd_name == "quit":
             r = send(sock, {"quit": {}})
         else:


### PR DESCRIPTION
Follow-up to the code-block background fix (#5): makes the cold-first-paint repro a first-class harness affordance and documents the technique.

## What

- **`recreate-view` harness command** — bumps a SwiftUI identity nonce (`DocumentState.viewRebuildGeneration`) on the markdown preview, tearing down and recreating its `NSViewRepresentable` (a fresh cold `makeNSView`) in an already-running session, without relaunching. The nonce stays `0` in normal use, so production view identity is unchanged.
- Guards the no-preview case (welcome/source/plain) so it doesn't await a render that never fires.
- `scripts/mkdn-ctl recreate-view` verb + round-trip test.
- **Docs** — a "cold first-paint testing" section in `docs/visual-testing-with-mkdn-ctl.md` (cold launch with a file arg, or `recreate-view`, then capture before any scroll/hover).

## Why

First-paint bugs (like the code-block background estimated-layout bug) only appear on a cold `makeNSView`. The warm `load` path can't reproduce them; previously the only repro was relaunching the whole app with a file argument.

## Verification

- Plan green-lit by codex; implementation reviewed clean by codex.
- Empirically proven: with the code-block fix disabled, a warmed view renders correctly but `recreate-view` makes the bug reappear — confirming it forces the cold path.
- 817 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)