### PR TITLE
fix(comments): smart punctuation made prose uncommentable

### DIFF
--- a/mkdn/Core/Markdown/CriticMarkup.swift
+++ b/mkdn/Core/Markdown/CriticMarkup.swift
@@ -514,8 +514,8 @@ enum CriticMarkup {
     /// invisible mkdn anchors and sidecar are ignored in both — the authoring
     /// safety net (see `wrapComment`).
     private static func rendersUnchanged(raw: String, candidate: String) -> Bool {
-        renderSignature(Document(parsing: raw, options: []))
-            == renderSignature(Document(parsing: candidate, options: []))
+        renderSignature(Document(parsing: raw, options: MarkdownRenderer.parseOptions))
+            == renderSignature(Document(parsing: candidate, options: MarkdownRenderer.parseOptions))
     }
 
     /// A structural + text signature of a parsed document that ignores mkdn

--- a/mkdn/Core/Markdown/MarkdownRenderer.swift
+++ b/mkdn/Core/Markdown/MarkdownRenderer.swift
@@ -6,9 +6,20 @@ import SwiftUI
 /// Uses apple/swift-markdown for parsing and a custom `MarkdownVisitor`
 /// for rendering each node type as SwiftUI views.
 public enum MarkdownRenderer {
+    /// Parse options shared by every `Document(parsing:)` call in the app.
+    ///
+    /// `.disableSmartOpts` turns off swift-markdown's smart-punctuation
+    /// substitution (`"` → `“”`, `'` → `’`, `--` → `–`, `...` → `…`), which is on
+    /// by default. The comment feature anchors selections by mapping rendered
+    /// text verbatim back to source offsets; smart substitution makes the
+    /// rendered text differ from source, dropping the source span for any run
+    /// that contains a quote/apostrophe/dash/ellipsis and silently making it
+    /// uncommentable. Parsing verbatim keeps render and source identical.
+    public static let parseOptions: ParseOptions = .disableSmartOpts
+
     /// Parse raw Markdown text into a structured document.
     public static func parse(_ text: String) -> Document {
-        Document(parsing: text)
+        Document(parsing: text, options: parseOptions)
     }
 
     /// Render a Markdown document into an array of indexed block-level elements.

--- a/mkdnTests/Unit/Core/CommentRangeResolverTests.swift
+++ b/mkdnTests/Unit/Core/CommentRangeResolverTests.swift
@@ -104,6 +104,38 @@ struct CommentRangeResolverTests {
         #expect(resolver.rawRange(forBuilderRange: NSRange(location: 2, length: 0)) == nil)
     }
 
+    // MARK: - Smart-punctuation regression
+
+    @Test("Rendered text keeps punctuation verbatim (smart substitution disabled)")
+    func rendersPunctuationVerbatim() {
+        let raw = "don't say \"hi\" -- or ... do"
+        let (_, result) = pipeline(raw)
+        // No “ ” ’ – … substitution: rendered text maps to source 1:1 for comments.
+        #expect(result.attributedString.string.contains(raw))
+    }
+
+    @Test("A phrase containing quotes/apostrophes is commentable")
+    func commentableAcrossSmartPunctuation() {
+        let raw = "the recipient's op is mandatory, so \"recipient last\" is a rule"
+        let (document, result) = pipeline(raw)
+        let resolver = CommentRangeResolver(document: document, sourceMap: result.sourceMap)
+
+        let nsRange = builderRange(of: "recipient last", in: result)
+        let rawRange = try! #require(resolver.rawRange(forBuilderRange: nsRange))
+        #expect(raw[rawRange] == "recipient last")
+    }
+
+    @Test("A quoted phrase after a soft line break is commentable")
+    func commentableAfterSoftBreak() {
+        let raw = "the partials commute, so\n\"recipient last\" is an orchestration rule"
+        let (document, result) = pipeline(raw)
+        let resolver = CommentRangeResolver(document: document, sourceMap: result.sourceMap)
+
+        let nsRange = builderRange(of: "recipient last", in: result)
+        let rawRange = try! #require(resolver.rawRange(forBuilderRange: nsRange))
+        #expect(raw[rawRange] == "recipient last")
+    }
+
     @Test("commentsByID exposes parsed comments keyed by id")
     func commentsByID() {
         let raw = CommentFixture.doc("a and b", comments: [("a", "c1", "one"), ("b", "c2", "two")])


### PR DESCRIPTION
## Problem

Selecting prose and choosing "Add Comment…" silently did nothing for most text — e.g. the phrase `"recipient last"` inside a paragraph. Reported in a real doc.

## Root cause

swift-markdown's `Document(parsing:)` applies **smart punctuation by default** (`"`→`""`, `'`→`'`, `--`→`–`, `...`→`…`). The comment feature anchors a selection by mapping rendered text **verbatim** back to source offsets (`MarkdownVisitor.linearSpan` requires `source[range] == text.string`). Smart substitution makes the rendered run differ from source, so the run gets **no source span** and the whole run becomes uncommentable. Apostrophes and quotes appear in most prose, so this broke commenting broadly — not just one phrase.

## Fix

Parse with `.disableSmartOpts` via a shared `MarkdownRenderer.parseOptions` constant, applied at both `Document(parsing:)` sites (the renderer and CriticMarkup's structural-equivalence check). Rendered text is now a verbatim copy of source — exactly what the comment source-map assumes.

**Trade-off (chosen deliberately):** quotes/dashes render straight (`"`, `--`, `...`) instead of typographic (`""`, `–`, `…`). The alternative (relax the mapping to length-preserving substitutions only) was rejected because it left `--`/`...` prose uncommentable and weakened the verbatim invariant.

## Verification

- Codex recommended this approach (Option A) and reviewed the implementation clean.
- Regression tests: prose with quotes/apostrophes (incl. the reported `"recipient last"` after a soft break) is now commentable; rendered text stays verbatim.
- Full suite: 820 tests green (no test assumed curly output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)