### PR TITLE
Block-offset consumers: scroll-marker track, minimap, anchored comment cards + intra-block precision

### DIFF
--- a/fixtures/comments-test.md
+++ b/fixtures/comments-test.md
@@ -12,47 +12,53 @@ See the <mkdn-comment id="d2" edge="start"/>[documentation](https://example.com)
     {
       "body" : "Nice imagery — keep it.",
       "id" : "d1",
-      "prefix" : "# v3 Comments Demo\n\nThe ",
+      "norm" : 1,
+      "prefix" : "",
       "quote" : "quick brown fox",
-      "suffix" : " jumps over the lazy dog near th"
+      "suffix" : ""
     },
     {
       "body" : "Link the v3 page instead.",
       "id" : "d2",
-      "prefix" : "g near the river bank.\n\nSee the ",
-      "quote" : "[documentation](https://example.com)",
-      "suffix" : " and run `swift build` to begin."
+      "norm" : 1,
+      "prefix" : "",
+      "quote" : "documentation",
+      "suffix" : ""
     },
     {
       "body" : "Should this be `swift test`?",
       "id" : "d3",
-      "prefix" : "n](https://example.com) and run ",
-      "quote" : "`swift build`",
-      "suffix" : " to begin.\n\nFirst word of this p"
+      "norm" : 1,
+      "prefix" : "",
+      "quote" : "swift build",
+      "suffix" : ""
     },
     {
       "body" : "Line\u002dstart comment — works now!",
       "id" : "d4",
-      "prefix" : "nd run `swift build` to begin.\n\n",
-      "quote" : "First word",
-      "suffix" : " of this paragraph is commentabl"
+      "norm" : 1,
+      "prefix" : "",
+      "quote" : "first word",
+      "suffix" : ""
     },
     {
       "body" : "Whole clause.",
       "id" : "d5",
-      "prefix" : " quick brown fox jumps over the ",
+      "norm" : 1,
+      "prefix" : "",
       "quote" : "lazy dog near the river bank",
-      "suffix" : ".\n\nSee the [documentation](https"
+      "suffix" : ""
     },
     {
       "body" : "Inner comment (overlap).",
       "id" : "d6",
-      "prefix" : "umps over the lazy dog near the ",
+      "norm" : 1,
+      "prefix" : "",
       "quote" : "river bank",
-      "suffix" : ".\n\nSee the [documentation](https"
+      "suffix" : ""
     },
     {
-      "body" : "Recovered via TextQuote (no anchors).",
+      "body" : "Detached demo — no norm, so the anchor can't be trusted.",
       "id" : "orphan",
       "prefix" : "",
       "quote" : "jumps over",

--- a/fixtures/marker-track-test.md
+++ b/fixtures/marker-track-test.md
@@ -1,0 +1,111 @@
+# Marker Track Test
+
+This document exercises the scroll-marker track: many headings at varied
+levels, several comments, and enough height to scroll. The gutter to the right
+of the preview should show heading ticks (longer and bolder for higher levels),
+accent comment ticks, and a thumb that tracks the viewport.
+
+## Introduction
+
+The quick brown fox jumps over the lazy dog. This opening paragraph gives the
+first section some body so the headings below are spaced apart on the track.
+
+Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump.
+The five boxing wizards jump quickly through the misty morning air downtown.
+
+### Background
+
+Sphinx of black quartz, judge my vow. A wizard's job is to vex chumps quickly
+in fog. Waltz, bad nymph, for quick jigs vex across the open meadow at dawn.
+
+The early morning light filtered through the tall windows of the study, casting
+long shadows across the worn wooden floor and the stacks of unread manuscripts.
+
+### Motivation
+
+We hold these truths about layout to be self-evident: that all blocks have a
+top, that the top is measurable without full layout, and that estimation beats
+realization for off-screen content. This sentence is a unique comment anchor.
+
+## Architecture
+
+Glib jocks quiz nymph to vex dwarf. The job requires a vexingly quick mind and
+a fox-like patience for the chumps who quibble over pixel-level alignment.
+
+### Coordinate Spaces
+
+Bright vixens jump; dozy fowl quack. The marks live in scroll space, the same
+basis the heading navigation already uses, so a clicked tick lands true.
+
+A document at rest has its viewport at the origin. As the reader scrolls, the
+thumb on the track descends in proportion, a faithful miniature of the whole.
+
+### The Block Model
+
+Jackdaws love my big sphinx of quartz. Each top-level block contributes one span
+to the height model, and each span resolves to exactly one tick on the gutter.
+
+#### Spans and Offsets
+
+Crazy Fredrick bought many very exquisite opal jewels. The offsets convert to y
+positions, the y positions normalize against the real document height, and only
+then do they reach the view, which knows nothing of TextKit.
+
+## Rendering
+
+The job of waxing linoleum frequently peeves chintzy kids. The track renders
+heading ticks flush right and comment ticks flush left in the accent color.
+
+### Themes
+
+Both Solarized themes must read cleanly. The foreground-derived heading ticks
+and the accent comment ticks should each have enough contrast on either ground.
+
+### Interaction
+
+Amazingly few discotheques provide jukeboxes. A tap on the track jumps the
+preview to the nearest mark, animated, so navigation feels deliberate.
+
+## Conclusion
+
+We few, we happy few, we band of blocks. This closing section sits near the
+bottom so the thumb has somewhere to travel and a low tick to anchor against.
+
+The final paragraph of the marker track test confirms that the deepest scroll
+position still resolves a sensible nearest mark for the click-to-jump gesture.
+
+<!--mkdn-comments
+{
+  "comments" : [
+    {
+      "body" : "Define the scope here.",
+      "id" : "c1",
+      "prefix" : "",
+      "quote" : "This sentence is a unique comment anchor.",
+      "suffix" : ""
+    },
+    {
+      "body" : "Spell out the basis.",
+      "id" : "c2",
+      "prefix" : "",
+      "quote" : "the same\nbasis the heading navigation already uses",
+      "suffix" : ""
+    },
+    {
+      "body" : "One span, one tick — good invariant.",
+      "id" : "c3",
+      "prefix" : "",
+      "quote" : "each span resolves to exactly one tick on the gutter",
+      "suffix" : ""
+    },
+    {
+      "body" : "Confirm animation feels right.",
+      "id" : "c4",
+      "prefix" : "",
+      "quote" : "jumps the\npreview to the nearest mark, animated",
+      "suffix" : ""
+    }
+  ],
+  "v" : 1
+}
+-->

--- a/fixtures/marker-track-test.md
+++ b/fixtures/marker-track-test.md
@@ -80,20 +80,23 @@ position still resolves a sensible nearest mark for the click-to-jump gesture.
     {
       "body" : "Define the scope here.",
       "id" : "c1",
+      "norm" : 1,
       "prefix" : "",
-      "quote" : "This sentence is a unique comment anchor.",
+      "quote" : "this sentence is a unique comment anchor.",
       "suffix" : ""
     },
     {
       "body" : "Spell out the basis.",
       "id" : "c2",
+      "norm" : 1,
       "prefix" : "",
-      "quote" : "the same\nbasis the heading navigation already uses",
+      "quote" : "the same basis the heading navigation already uses",
       "suffix" : ""
     },
     {
       "body" : "One span, one tick — good invariant.",
       "id" : "c3",
+      "norm" : 1,
       "prefix" : "",
       "quote" : "each span resolves to exactly one tick on the gutter",
       "suffix" : ""
@@ -101,8 +104,9 @@ position still resolves a sensible nearest mark for the click-to-jump gesture.
     {
       "body" : "Confirm animation feels right.",
       "id" : "c4",
+      "norm" : 1,
       "prefix" : "",
-      "quote" : "jumps the\npreview to the nearest mark, animated",
+      "quote" : "jumps the preview to the nearest mark, animated",
       "suffix" : ""
     }
   ],

--- a/mkdn/App/DocumentState.swift
+++ b/mkdn/App/DocumentState.swift
@@ -82,6 +82,14 @@
             currentFileURL != nil && fileKind == .markdown && viewMode == .previewOnly
         }
 
+        /// Whether the document minimap replaces the slim marker track in the gutter.
+        public var isMinimapVisible = false
+
+        /// Whether the minimap toggle is meaningful: a markdown document is loaded.
+        public var canShowMinimap: Bool {
+            currentFileURL != nil && fileKind == .markdown
+        }
+
         /// Current sidebar width in points.
         public var sidebarWidth: CGFloat = 240
 
@@ -220,6 +228,11 @@
         /// Toggle the comment sidebar's visibility.
         public func toggleCommentSidebar() {
             isCommentSidebarVisible.toggle()
+        }
+
+        /// Toggle the document minimap (it swaps in for the marker track).
+        public func toggleMinimap() {
+            isMinimapVisible.toggle()
         }
     }
 #endif

--- a/mkdn/App/MkdnCommands.swift
+++ b/mkdn/App/MkdnCommands.swift
@@ -163,6 +163,12 @@
                     // Match the render gate, so the shortcut never flips an
                     // invisible flag (no document, wrong mode, non-markdown).
                     .disabled(!(documentState?.canShowCommentSidebar ?? false))
+
+                    Button("Toggle Minimap") {
+                        documentState?.toggleMinimap()
+                    }
+                    .keyboardShortcut("m", modifiers: [.command, .shift])
+                    .disabled(!(documentState?.canShowMinimap ?? false))
                 }
 
                 Section {

--- a/mkdn/Core/Markdown/DocumentBlockOffsets.swift
+++ b/mkdn/Core/Markdown/DocumentBlockOffsets.swift
@@ -28,6 +28,38 @@ public struct DocumentBlockOffsets {
         blocks.first { $0.index == index }?.top
     }
 
+    /// Text-view-space top y of the line a character `location` sits on — the block
+    /// top plus the height of the block's text above that line. Refines the block-
+    /// granular `offset(forBlockIndex:)` to intra-block precision (so two comments in
+    /// one paragraph anchor at their own lines), still without TextKit fragment
+    /// layout: it's the same Core Text prefix measure `compute` uses, scoped to the
+    /// block. `nil` when the location maps to no block.
+    @MainActor
+    public func characterY(
+        at location: Int,
+        in attributedString: NSAttributedString,
+        model: DocumentHeightModel,
+        textWidth: CGFloat
+    ) -> CGFloat? {
+        guard textWidth > 0,
+              let blockIndex = model.blockIndex(containing: location),
+              let blockTop = offset(forBlockIndex: blockIndex),
+              let block = model.blocks.first(where: { $0.index == blockIndex })
+        else { return nil }
+        let prefixLength = location - block.range.location
+        guard prefixLength > 0, location <= attributedString.length else { return blockTop }
+        // Height of the block's text above `location`. Whether `location`'s own line is
+        // counted depends on it falling at a wrap boundary — which needs real layout to
+        // know — so this lands within one line: exact when `location` starts a line,
+        // up to a line low otherwise. Biased low on purpose: a card never floats above
+        // the comment it points at.
+        let intra = DocumentHeightEstimator.contentHeight(
+            of: attributedString.attributedSubstring(
+                from: NSRange(location: block.range.location, length: prefixLength)),
+            textWidth: textWidth)
+        return blockTop + intra
+    }
+
     /// Source index of the block whose span contains `y` (the last block whose top
     /// is at or above `y`), clamped to the document; nil when empty.
     public func blockIndex(atY y: CGFloat) -> Int? {

--- a/mkdn/Core/Markdown/DocumentBlockOffsets.swift
+++ b/mkdn/Core/Markdown/DocumentBlockOffsets.swift
@@ -53,10 +53,15 @@ public struct DocumentBlockOffsets {
         // know — so this lands within one line: exact when `location` starts a line,
         // up to a line low otherwise. Biased low on purpose: a card never floats above
         // the comment it points at.
-        let intra = DocumentHeightEstimator.contentHeight(
+        var intra = DocumentHeightEstimator.contentHeight(
             of: attributedString.attributedSubstring(
                 from: NSRange(location: block.range.location, length: prefixLength)),
             textWidth: textWidth)
+        // A prefix ending at an internal newline (e.g. line 2+ of a code block) carries
+        // the same phantom empty line `compute` subtracts at block boundaries — drop it.
+        if (attributedString.string as NSString).character(at: location - 1) == 0x0A {
+            intra -= Self.trailingNewlinePhantom(at: location - 1, in: attributedString)
+        }
         return blockTop + intra
     }
 

--- a/mkdn/Core/Markdown/DocumentHeightModel.swift
+++ b/mkdn/Core/Markdown/DocumentHeightModel.swift
@@ -1,19 +1,5 @@
 import Foundation
 
-/// A block's visual category, for the minimap's per-block bands. Groups the
-/// renderer's block cases into the kinds that warrant distinct colouring.
-public enum BlockKind: Equatable {
-    case heading(level: Int)
-    case paragraph
-    case code
-    case list
-    case blockquote
-    case table
-    case image
-    case math
-    case divider
-}
-
 /// One top-level block's span in the final attributed string, in document order.
 /// The builder emits these so the height engine can locate per-block boundaries
 /// without re-parsing the markdown.

--- a/mkdn/Core/Markdown/DocumentHeightModel.swift
+++ b/mkdn/Core/Markdown/DocumentHeightModel.swift
@@ -14,3 +14,18 @@ public struct BlockSpan {
 public struct DocumentHeightModel {
     public let blocks: [BlockSpan]
 }
+
+extension DocumentHeightModel {
+    /// Source index of the block containing `location`. Blocks are contiguous
+    /// spans, so a location on a span boundary belongs to the later block; a
+    /// location at or past the document end falls to the last block.
+    public func blockIndex(containing location: Int) -> Int? {
+        for block in blocks where NSLocationInRange(location, block.range) {
+            return block.index
+        }
+        if let last = blocks.last, location >= last.range.location {
+            return last.index
+        }
+        return nil
+    }
+}

--- a/mkdn/Core/Markdown/DocumentHeightModel.swift
+++ b/mkdn/Core/Markdown/DocumentHeightModel.swift
@@ -1,11 +1,32 @@
 import Foundation
 
+/// A block's visual category, for the minimap's per-block bands. Groups the
+/// renderer's block cases into the kinds that warrant distinct colouring.
+public enum BlockKind: Equatable {
+    case heading(level: Int)
+    case paragraph
+    case code
+    case list
+    case blockquote
+    case table
+    case image
+    case math
+    case divider
+}
+
 /// One top-level block's span in the final attributed string, in document order.
 /// The builder emits these so the height engine can locate per-block boundaries
 /// without re-parsing the markdown.
 public struct BlockSpan {
     public let index: Int // source block index
     public let range: NSRange // range in the final attributed string
+    public let kind: BlockKind
+
+    public init(index: Int, range: NSRange, kind: BlockKind = .paragraph) {
+        self.index = index
+        self.range = range
+        self.kind = kind
+    }
 }
 
 /// Per-block spans emitted alongside the attributed string. Consumed by

--- a/mkdn/Core/Markdown/MarkdownBlock.swift
+++ b/mkdn/Core/Markdown/MarkdownBlock.swift
@@ -43,6 +43,22 @@ public enum MarkdownBlock: Identifiable {
         }
     }
 
+    /// The block's minimap category. Folds the rendered-as-visuals cases
+    /// (image, Mermaid) and the code-like cases (code, HTML) together.
+    public var blockKind: BlockKind {
+        switch self {
+        case let .heading(level, _): .heading(level: level)
+        case .paragraph: .paragraph
+        case .codeBlock, .htmlBlock: .code
+        case .orderedList, .unorderedList: .list
+        case .blockquote: .blockquote
+        case .table: .table
+        case .image, .mermaidBlock: .image
+        case .mathBlock: .math
+        case .thematicBreak: .divider
+        }
+    }
+
     public var id: String {
         switch self {
         case let .heading(level, text):

--- a/mkdn/Core/Markdown/MarkdownBlock.swift
+++ b/mkdn/Core/Markdown/MarkdownBlock.swift
@@ -18,6 +18,20 @@ public struct TableColumn: Sendable {
     }
 }
 
+/// A block's visual category, for the minimap's per-block bands. Groups the
+/// renderer's block cases into the kinds that warrant distinct colouring.
+public enum BlockKind: Equatable {
+    case heading(level: Int)
+    case paragraph
+    case code
+    case list
+    case blockquote
+    case table
+    case image
+    case math
+    case divider
+}
+
 /// Represents a rendered Markdown block element.
 public enum MarkdownBlock: Identifiable {
     case heading(level: Int, text: AttributedString)

--- a/mkdn/Core/Markdown/MarkdownTextStorageBuilder.swift
+++ b/mkdn/Core/Markdown/MarkdownTextStorageBuilder.swift
@@ -151,7 +151,8 @@ public enum MarkdownTextStorageBuilder {
             )
             blockSpans.append(BlockSpan(
                 index: indexedBlock.index,
-                range: NSRange(location: blockStart, length: result.length - blockStart)
+                range: NSRange(location: blockStart, length: result.length - blockStart),
+                kind: indexedBlock.block.blockKind
             ))
 
             // Collapse the first block's top spacing so textContainerInset

--- a/mkdn/Core/TestHarness/HarnessCommand.swift
+++ b/mkdn/Core/TestHarness/HarnessCommand.swift
@@ -85,6 +85,9 @@
         /// Toggle the right-docked comment sidebar's visibility.
         case toggleCommentSidebar
 
+        /// Toggle the document minimap (swaps in for the marker track).
+        case toggleMinimap
+
         /// Scroll to + flash the first resolved comment (exercises the sidebar's
         /// jump-to-comment path without simulating a card tap).
         case jumpFirstComment

--- a/mkdn/Core/TestHarness/TestHarnessHandler.swift
+++ b/mkdn/Core/TestHarness/TestHarnessHandler.swift
@@ -27,6 +27,8 @@
                 await handleAddComment(substring: substring, body: body)
             case .toggleCommentSidebar:
                 await handleToggleCommentSidebar()
+            case .toggleMinimap:
+                await handleToggleMinimap()
             case .jumpFirstComment:
                 await handleJumpComment(index: 0)
             case let .jumpCommentAt(index):
@@ -134,6 +136,14 @@
             }
             docState.toggleCommentSidebar()
             return .ok(message: "Comment sidebar: \(docState.isCommentSidebarVisible ? "open" : "closed")")
+        }
+
+        private static func handleToggleMinimap() async -> HarnessResponse {
+            guard let docState = documentState else {
+                return .error("No document state available")
+            }
+            docState.toggleMinimap()
+            return .ok(message: "Minimap: \(docState.isMinimapVisible ? "shown" : "hidden")")
         }
 
         /// The text view and the resolved comment at `index` in document order, or

--- a/mkdn/Features/Viewer/Views/AnchoredCommentPlacement.swift
+++ b/mkdn/Features/Viewer/Views/AnchoredCommentPlacement.swift
@@ -1,0 +1,28 @@
+#if os(macOS)
+    import Foundation
+
+    /// Resolves comment-card tops from their desired anchors with downward-only
+    /// collision. Pure (no SwiftUI), so the layout math is unit-testable apart from
+    /// the ``Layout``.
+    ///
+    /// Each card sits at its anchor (`commentY − viewportTop`, so it tracks the text
+    /// it annotates), unless that would overlap the card above — then it drops to just
+    /// below it. The first card keeps its anchor even when negative: a comment scrolled
+    /// above the viewport keeps a negative top and clips out, rather than snapping into
+    /// view and shoving the rest down.
+    enum AnchoredCommentPlacement {
+        /// `anchors` and `heights` are parallel, in document (top-down) order.
+        static func tops(anchors: [CGFloat], heights: [CGFloat], gap: CGFloat) -> [CGFloat] {
+            var tops: [CGFloat] = []
+            tops.reserveCapacity(anchors.count)
+            var cursor = -CGFloat.greatestFiniteMagnitude
+            for index in anchors.indices {
+                let top = max(anchors[index], cursor)
+                tops.append(top)
+                let height = index < heights.count ? heights[index] : 0
+                cursor = top + height + gap
+            }
+            return tops
+        }
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/AnchoredCommentsLayout.swift
+++ b/mkdn/Features/Viewer/Views/AnchoredCommentsLayout.swift
@@ -1,0 +1,44 @@
+#if os(macOS)
+    import SwiftUI
+
+    /// A card's desired top in the sidebar. Carried as a layout value so the layout
+    /// reads each subview's own anchor rather than a parallel array that could fall
+    /// out of step with the cards.
+    private struct CommentCardAnchor: LayoutValueKey {
+        static let defaultValue: CGFloat = 0
+    }
+
+    extension View {
+        func commentCardAnchor(_ top: CGFloat) -> some View {
+            layoutValue(key: CommentCardAnchor.self, value: top)
+        }
+    }
+
+    /// Places comment cards at their anchors with downward-only collision
+    /// (``AnchoredCommentPlacement``), filling the container so an off-screen card
+    /// clips out rather than reflowing the rest. The cards follow the document
+    /// because the host recomputes each anchor from the live `viewportTop`.
+    struct AnchoredCommentsLayout: Layout {
+        var gap: CGFloat = 8
+
+        func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+            proposal.replacingUnspecifiedDimensions()
+        }
+
+        func placeSubviews(
+            in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+        ) {
+            let cardProposal = ProposedViewSize(width: bounds.width, height: nil)
+            let anchors = subviews.map { $0[CommentCardAnchor.self] }
+            let heights = subviews.map { $0.sizeThatFits(cardProposal).height }
+            let tops = AnchoredCommentPlacement.tops(anchors: anchors, heights: heights, gap: gap)
+            for (index, subview) in subviews.enumerated() {
+                subview.place(
+                    at: CGPoint(x: bounds.minX, y: bounds.minY + tops[index]),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(width: bounds.width, height: heights[index])
+                )
+            }
+        }
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/CommentSidebarView.swift
+++ b/mkdn/Features/Viewer/Views/CommentSidebarView.swift
@@ -12,23 +12,19 @@
         let suffix: String
     }
 
-    /// Which comments the sidebar lists. `all` shows on-page comments then
-    /// detached ones below; `detached` shows only the detached.
-    enum CommentFilter: String, CaseIterable, Identifiable {
-        case all = "All"
-        case detached = "Detached"
-
-        var id: String { rawValue }
-    }
-
-    /// The right-docked comment panel: an "On this page" section (resolved
-    /// comments) and a "Detached" section (anchors that couldn't be located),
-    /// gated by a segmented filter. Pure presentation — the host maps
-    /// ``ResolvedComments`` into items and supplies the jump/delete actions.
+    /// The right-docked comment panel. Active cards float anchored beside the text
+    /// they annotate (``AnchoredCommentsLayout``) and follow it on scroll; a floating
+    /// header sits over the top, and detached comments (anchors that couldn't be
+    /// located) collect in a footer. Pure presentation — the host maps
+    /// ``ResolvedComments`` into items and supplies the jump/delete actions and the
+    /// ``PreviewMapState`` the anchors come from.
     struct CommentSidebarView: View {
         let active: [CommentSidebarItem]
         let detached: [CommentSidebarItem]
         let theme: AppTheme
+        /// Published positions: each active comment's scroll-space `y` plus the live
+        /// `viewportTop`, so cards anchor beside the text and follow it on scroll.
+        let mapState: PreviewMapState
         let onJump: (String) -> Void
         let onDelete: (String) -> Void
         let onClose: () -> Void
@@ -37,32 +33,61 @@
         let onHover: (String?) -> Void
 
         static let width: CGFloat = 300
-
-        @State private var filter: CommentFilter = .all
-        @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-        private var motion: MotionPreference {
-            MotionPreference(reduceMotion: reduceMotion)
-        }
-
-        private var hasActive: Bool { filter == .all && !active.isEmpty }
-        private var hasDetached: Bool { !detached.isEmpty }
-        private var isEmpty: Bool { !hasActive && !hasDetached }
+        /// The preview's `textContainerInset.height`, added back so a card lands
+        /// beside the live text rather than the inset-subtracted scroll-space mark.
+        private static let previewTopInset: CGFloat = 32
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 12) {
-                header
-                CommentFilterPicker(filter: $filter, theme: theme, motion: motion)
-                content
-                    .animation(motion.resolved(.quickShift), value: active)
-                    .animation(motion.resolved(.quickShift), value: detached)
-                    .animation(motion.resolved(.quickShift), value: filter)
+            let map = mapState.documentMap
+            let cardTops = Dictionary(
+                map.comments.map { ($0.id, $0.y - map.viewportTop + Self.previewTopInset) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            ZStack(alignment: .top) {
+                if active.isEmpty, detached.isEmpty {
+                    emptyState
+                } else {
+                    anchoredActiveCards(tops: cardTops)
+                }
+                headerBar
+                if !detached.isEmpty {
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        detachedFooter
+                    }
+                }
             }
-            .padding(16)
-            .frame(width: Self.width, alignment: .leading)
+            .frame(width: Self.width)
             .frame(maxHeight: .infinity, alignment: .top)
             .background(theme.colors.backgroundSecondary)
             .environment(\.colorScheme, theme.colorScheme)
+        }
+
+        /// Active cards anchored beside their text, clipped to the panel. No implicit
+        /// animation: the per-frame reposition from the live `viewportTop` is the
+        /// scroll-follow, so animating it would lag the text.
+        private func anchoredActiveCards(tops: [String: CGFloat]) -> some View {
+            AnchoredCommentsLayout(gap: 8) {
+                ForEach(active) { item in
+                    ActiveCommentCard(item: item, theme: theme, onJump: onJump, onHover: onHover)
+                        .commentCardAnchor(tops[item.id] ?? 0)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .clipped()
+        }
+
+        /// Opaque header pinned to the top; active cards scroll under it.
+        private var headerBar: some View {
+            VStack(spacing: 0) {
+                header
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+                    .background(theme.colors.backgroundSecondary)
+                Spacer(minLength: 0)
+            }
         }
 
         private var header: some View {
@@ -82,109 +107,35 @@
             }
         }
 
-        @ViewBuilder
-        private var content: some View {
-            if isEmpty {
-                emptyState
-                    .transition(.opacity)
-            } else {
+        private var detachedFooter: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("DETACHED (\(detached.count))")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(theme.colors.foregroundSecondary)
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
-                        if hasActive {
-                            section("On this page") {
-                                ForEach(active) { item in
-                                    ActiveCommentCard(
-                                        item: item, theme: theme,
-                                        onJump: onJump, onHover: onHover
-                                    )
-                                    .transition(.opacity)
-                                }
-                            }
-                        }
-                        if hasDetached {
-                            section("Detached (\(detached.count))") {
-                                Text("These comments' anchors are no longer in the document.")
-                                    .font(.caption)
-                                    .foregroundStyle(theme.colors.foregroundSecondary)
-                                ForEach(detached) { item in
-                                    DetachedCommentCard(
-                                        item: item, theme: theme, onDelete: onDelete
-                                    )
-                                    .transition(.opacity)
-                                }
-                            }
-                            .transition(.opacity)
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(detached) { item in
+                            DetachedCommentCard(item: item, theme: theme, onDelete: onDelete)
                         }
                     }
-                    .padding(.bottom, 8)
                 }
                 .scrollIndicators(.never)
-                .transition(.opacity)
+                .frame(maxHeight: 180)
             }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.colors.backgroundSecondary)
         }
 
         private var emptyState: some View {
             VStack(spacing: 6) {
                 Image(systemName: "text.bubble")
                     .font(.system(size: 22))
-                Text(filter == .all ? "No comments yet" : "Nothing here")
+                Text("No comments yet")
                     .font(.callout)
             }
             .foregroundStyle(theme.colors.foregroundSecondary)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-
-        private func section(
-            _ title: String, @ViewBuilder _ rows: () -> some View
-        ) -> some View {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(title.uppercased())
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(theme.colors.foregroundSecondary)
-                rows()
-            }
-        }
-    }
-
-    /// Segmented filter control, themed (selected segment filled with `accent`).
-    /// Hand-rolled rather than a native segmented `Picker` so every color is a
-    /// ``ThemeColors`` token instead of the system accent.
-    private struct CommentFilterPicker: View {
-        @Binding var filter: CommentFilter
-        let theme: AppTheme
-        let motion: MotionPreference
-
-        @Namespace private var selection
-
-        var body: some View {
-            HStack(spacing: 0) {
-                ForEach(CommentFilter.allCases) { option in
-                    let selected = option == filter
-                    Text(option.rawValue)
-                        .font(.caption.weight(selected ? .semibold : .regular))
-                        .foregroundStyle(selected ? theme.colors.background : theme.colors.foregroundSecondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 5)
-                        .background {
-                            // One matched capsule that slides between segments
-                            // rather than two that blink on/off.
-                            if selected {
-                                RoundedRectangle(cornerRadius: 5)
-                                    .fill(theme.colors.accent)
-                                    .matchedGeometryEffect(id: "selection", in: selection)
-                            }
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation(motion.resolved(.quickShift)) { filter = option }
-                        }
-                        .pointingHandCursor()
-                }
-            }
-            .padding(2)
-            .background(theme.colors.background)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.colors.border.opacity(0.5)))
         }
     }
 
@@ -253,8 +204,8 @@
                 onHover(inside ? item.id : nil)
             }
             // Clear the document emphasis if this card is removed while hovered
-            // (filter switch, delete, sidebar close) — onHover(false) doesn't fire
-            // on removal, so the accent pill would otherwise stay painted.
+            // (delete, sidebar close) — onHover(false) doesn't fire on removal, so
+            // the accent pill would otherwise stay painted.
             .onDisappear { if hovering { onHover(nil) } }
             .pointingHandCursor()
             .animation(.easeInOut(duration: 0.15), value: hovering)

--- a/mkdn/Features/Viewer/Views/CommentSidebarView.swift
+++ b/mkdn/Features/Viewer/Views/CommentSidebarView.swift
@@ -44,18 +44,19 @@
                 uniquingKeysWith: { first, _ in first }
             )
             ZStack(alignment: .top) {
-                if active.isEmpty, detached.isEmpty {
-                    emptyState
-                } else {
-                    anchoredActiveCards(tops: cardTops)
-                }
-                headerBar
-                if !detached.isEmpty {
-                    VStack(spacing: 0) {
-                        Spacer(minLength: 0)
+                // Cards fill the space above the footer (not under it): the footer is
+                // opaque, so an overlapping ZStack sibling would occlude bottom cards.
+                VStack(spacing: 0) {
+                    if active.isEmpty, detached.isEmpty {
+                        emptyState
+                    } else {
+                        anchoredActiveCards(tops: cardTops)
+                    }
+                    if !detached.isEmpty {
                         detachedFooter
                     }
                 }
+                headerBar
             }
             .frame(width: Self.width)
             .frame(maxHeight: .infinity, alignment: .top)

--- a/mkdn/Features/Viewer/Views/DocumentMinimap.swift
+++ b/mkdn/Features/Viewer/Views/DocumentMinimap.swift
@@ -2,10 +2,9 @@
     import SwiftUI
 
     /// A wider navigation panel showing the document's block structure as per-kind
-    /// colored bands, with comment marks and a viewport thumb — ``ScrollMarkerTrack``
-    /// zoomed out to the whole-document shape. Reads ``PreviewMapState/documentMap``
-    /// and jumps via ``PreviewMapState/scrollTo``; a tap (or drag) scrolls to the
-    /// matching fraction of the document, so clicking a band lands on that block.
+    /// colored bands, with comment marks and a viewport thumb. Reads
+    /// ``PreviewMapState/documentMap`` and jumps via ``PreviewMapState/scrollTo``:
+    /// a tap (or drag) scrolls to the matching fraction of the document.
     struct DocumentMinimap: View {
         let state: PreviewMapState
 
@@ -85,8 +84,7 @@
         }
 
         /// Band colour by kind — headings read strong and embedded content
-        /// (code/table/image/math) gets accent hues; body text recedes, so the
-        /// panel takes on the document's shape.
+        /// (code/table/image/math) gets accent hues; body text recedes.
         private func fillColor(_ kind: BlockKind) -> Color {
             switch kind {
             case .heading: colors.headingColor

--- a/mkdn/Features/Viewer/Views/DocumentMinimap.swift
+++ b/mkdn/Features/Viewer/Views/DocumentMinimap.swift
@@ -1,0 +1,112 @@
+#if os(macOS)
+    import SwiftUI
+
+    /// A wider navigation panel showing the document's block structure as per-kind
+    /// colored bands, with comment marks and a viewport thumb — ``ScrollMarkerTrack``
+    /// zoomed out to the whole-document shape. Reads ``PreviewMapState/documentMap``
+    /// and jumps via ``PreviewMapState/scrollTo``; a tap (or drag) scrolls to the
+    /// matching fraction of the document, so clicking a band lands on that block.
+    struct DocumentMinimap: View {
+        let state: PreviewMapState
+
+        @Environment(AppSettings.self) private var appSettings
+
+        static let width: CGFloat = 64
+        private static let minThumbHeight: CGFloat = 24
+
+        private var colors: ThemeColors { appSettings.theme.colors }
+
+        var body: some View {
+            let map = state.documentMap
+            GeometryReader { geo in
+                let height = geo.size.height
+                ZStack(alignment: .topLeading) {
+                    colors.backgroundSecondary
+                    ForEach(map.blocks) { band in
+                        bandView(
+                            band,
+                            top: map.normalized(band.y) * height,
+                            length: scaled(band.height, map: map, trackHeight: height)
+                        )
+                    }
+                    ForEach(map.comments) { comment in
+                        commentMark(top: map.normalized(comment.y) * height)
+                    }
+                    viewportThumb(map: map, height: height)
+                }
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0).onEnded { value in
+                        guard height > 0, map.totalHeight > 0 else { return }
+                        let fraction = min(max(value.location.y / height, 0), 1)
+                        state.scrollTo?(fraction * map.totalHeight)
+                    }
+                )
+            }
+            .frame(width: Self.width)
+            .overlay(alignment: .leading) {
+                Rectangle().fill(colors.border).frame(width: 1)
+            }
+        }
+
+        /// A document length scaled onto the track (no clamp — heights, not positions).
+        private func scaled(_ length: CGFloat, map: PreviewDocumentMap, trackHeight: CGFloat) -> CGFloat {
+            guard map.totalHeight > 0 else { return 0 }
+            return (length / map.totalHeight) * trackHeight
+        }
+
+        private func bandView(_ band: BlockBand, top: CGFloat, length: CGFloat) -> some View {
+            let inset = inset(band.kind)
+            return RoundedRectangle(cornerRadius: 1)
+                .fill(fillColor(band.kind))
+                .frame(width: Self.width - inset * 2, height: max(length - 1, 1))
+                .offset(x: inset, y: top)
+        }
+
+        private func commentMark(top: CGFloat) -> some View {
+            Circle()
+                .fill(colors.accent)
+                .frame(width: 4, height: 4)
+                .offset(x: Self.width - 7, y: top - 2)
+        }
+
+        private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
+            let viewport = map.normalizedViewport
+            let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
+            return RoundedRectangle(cornerRadius: 2)
+                .fill(colors.foreground.opacity(0.1))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(colors.foreground.opacity(0.2), lineWidth: 1)
+                )
+                .frame(width: Self.width, height: thumbHeight)
+                .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
+        }
+
+        /// Band colour by kind — headings read strong and embedded content
+        /// (code/table/image/math) gets accent hues; body text recedes, so the
+        /// panel takes on the document's shape.
+        private func fillColor(_ kind: BlockKind) -> Color {
+            switch kind {
+            case .heading: colors.headingColor
+            case .paragraph: colors.foregroundSecondary.opacity(0.3)
+            case .code: colors.codeForeground.opacity(0.6)
+            case .list: colors.foregroundSecondary.opacity(0.5)
+            case .blockquote: colors.blockquoteBorder
+            case .table, .math: colors.accent.opacity(0.7)
+            case .image: colors.linkColor.opacity(0.8)
+            case .divider: colors.border
+            }
+        }
+
+        /// Horizontal inset by kind, so headings sit near full width and nested
+        /// blocks (quote, list) indent — mirroring the document's left margin.
+        private func inset(_ kind: BlockKind) -> CGFloat {
+            switch kind {
+            case .heading, .divider: 6
+            case .blockquote, .list: 14
+            default: 9
+            }
+        }
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/DocumentMinimap.swift
+++ b/mkdn/Features/Viewer/Views/DocumentMinimap.swift
@@ -72,17 +72,15 @@
 
         @ViewBuilder
         private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
-            let viewport = map.normalizedViewport
-            if viewport.height > 0 {
-                let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
+            if let thumb = map.thumbMetrics(trackHeight: height, minHeight: Self.minThumbHeight) {
                 RoundedRectangle(cornerRadius: 2)
                     .fill(colors.foreground.opacity(0.1))
                     .overlay(
                         RoundedRectangle(cornerRadius: 2)
                             .stroke(colors.foreground.opacity(0.2), lineWidth: 1)
                     )
-                    .frame(width: Self.width, height: thumbHeight)
-                    .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
+                    .frame(width: Self.width, height: thumb.height)
+                    .offset(y: thumb.offset)
             }
         }
 

--- a/mkdn/Features/Viewer/Views/DocumentMinimap.swift
+++ b/mkdn/Features/Viewer/Views/DocumentMinimap.swift
@@ -70,17 +70,20 @@
                 .offset(x: Self.width - 7, y: top - 2)
         }
 
+        @ViewBuilder
         private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
             let viewport = map.normalizedViewport
-            let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
-            return RoundedRectangle(cornerRadius: 2)
-                .fill(colors.foreground.opacity(0.1))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(colors.foreground.opacity(0.2), lineWidth: 1)
-                )
-                .frame(width: Self.width, height: thumbHeight)
-                .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
+            if viewport.height > 0 {
+                let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(colors.foreground.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(colors.foreground.opacity(0.2), lineWidth: 1)
+                    )
+                    .frame(width: Self.width, height: thumbHeight)
+                    .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
+            }
         }
 
         /// Band colour by kind — headings read strong and embedded content

--- a/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
+++ b/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
@@ -63,6 +63,9 @@
         /// Bumped per toggle so a superseded slide's completion can't tear down the
         /// anchor while a newer slide (fast re-toggle) is still re-pinning it.
         @State private var sidebarResizeToken = 0
+        /// Positions the coordinator publishes for the scroll-marker track, and the
+        /// track's scroll-to bridge back into it.
+        @State private var mapState = PreviewMapState()
 
         var body: some View {
             @Bindable var docState = documentState
@@ -88,6 +91,7 @@
                         resolvedComments: resolvedComments,
                         anchorTape: anchorTape,
                         commentRevision: commentRevision,
+                        mapState: mapState,
                         isLoadingGateActive: $docState.isLoadingGateActive
                     )
                     // Changing this identity tears down and recreates the text view's

--- a/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
+++ b/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
@@ -71,6 +71,8 @@
             @Bindable var docState = documentState
             GeometryReader { proxy in
                 let railWidth = CommentSidebarView.width * sidebarProgress
+                let gutterWidth = documentState.isMinimapVisible
+                    ? DocumentMinimap.width : ScrollMarkerTrack.width
                 HStack(spacing: 0) {
                     SelectableTextView(
                         attributedText: textStorageResult.attributedString,
@@ -102,11 +104,16 @@
                     .background(appSettings.theme.colors.background)
                     // The rail is a layout sibling, not an overlay: the preview's
                     // width shrinks as the rail opens, so the text reflows into the
-                    // narrowed viewport instead of being covered by it. The marker
-                    // track is a second, constant-width sibling on the preview's right.
-                    .frame(width: max(proxy.size.width - railWidth - ScrollMarkerTrack.width, 0))
+                    // narrowed viewport instead of being covered by it. The gutter
+                    // (marker track, or the minimap when toggled) is a second,
+                    // constant-width sibling on the preview's right.
+                    .frame(width: max(proxy.size.width - railWidth - gutterWidth, 0))
 
-                    ScrollMarkerTrack(state: mapState)
+                    if documentState.isMinimapVisible {
+                        DocumentMinimap(state: mapState)
+                    } else {
+                        ScrollMarkerTrack(state: mapState)
+                    }
 
                     if documentState.canShowCommentSidebar {
                         CommentSidebarView(

--- a/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
+++ b/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
@@ -102,8 +102,11 @@
                     .background(appSettings.theme.colors.background)
                     // The rail is a layout sibling, not an overlay: the preview's
                     // width shrinks as the rail opens, so the text reflows into the
-                    // narrowed viewport instead of being covered by it.
-                    .frame(width: max(proxy.size.width - railWidth, 0))
+                    // narrowed viewport instead of being covered by it. The marker
+                    // track is a second, constant-width sibling on the preview's right.
+                    .frame(width: max(proxy.size.width - railWidth - ScrollMarkerTrack.width, 0))
+
+                    ScrollMarkerTrack(state: mapState)
 
                     if documentState.canShowCommentSidebar {
                         CommentSidebarView(

--- a/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
+++ b/mkdn/Features/Viewer/Views/MarkdownPreviewView.swift
@@ -120,6 +120,7 @@
                             active: activeItems,
                             detached: detachedItems,
                             theme: appSettings.theme,
+                            mapState: mapState,
                             onJump: { jumpToComment($0) },
                             onDelete: { documentState.deleteComment(id: $0) },
                             onClose: { documentState.toggleCommentSidebar() },

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -23,8 +23,8 @@
     /// Heading, comment, and viewport positions within the preview's vertical
     /// extent, all in scroll (clip-view) coordinates. The text-view coordinator
     /// builds it from ``DocumentBlockOffsets`` once per content/width/scroll change;
-    /// the scroll-marker track (and later the minimap) consume it, so those views
-    /// never touch TextKit or the coordinate conversions.
+    /// the scroll-marker track consumes it, so those views never touch TextKit or
+    /// the coordinate conversions.
     struct PreviewDocumentMap: Equatable {
         /// The text view's real frame height — the denominator for normalizing a `y`
         /// onto a track, so marks track the actual scroller rather than the estimate.
@@ -39,9 +39,9 @@
     }
 
     extension PreviewDocumentMap {
-        /// Build the map from positions alone — no live `NSTextView` — so the math is
-        /// testable. `y` converts each block top from text-view space to scroll space
-        /// by subtracting `textContainerOriginY`, the basis heading navigation uses.
+        /// Build the map from positions alone — no live `NSTextView`. `y` converts
+        /// each block top from text-view space to scroll space by subtracting
+        /// `textContainerOriginY`, the basis heading navigation uses.
         static func build(
             headings: [HeadingNode],
             comments: [(id: String, range: NSRange)],

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -95,9 +95,8 @@
             )
         }
 
-        /// Each block's scroll-space `[y, y+height)` extent, by kind, for the minimap.
-        /// `height` runs to the next block's top; the last block fills to `totalHeight`,
-        /// so the bands tile the full document with no gaps.
+        /// Each block's scroll-space extent by kind, tiling the document with no gaps
+        /// (``BlockBand`` defines the per-band `height` convention).
         private static func blockBands(
             blockModel: DocumentHeightModel,
             offsets: DocumentBlockOffsets,

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -104,12 +104,15 @@
             totalHeight: CGFloat
         ) -> [BlockBand] {
             let spans = blockModel.blocks
+            // Index the block tops once: offset(forBlockIndex:) is a linear scan, so
+            // looking up each band's top and its next-top would be O(blocks^2). This
+            // runs on every rebuild, including the comment-only ones where the offsets
+            // are cached and this would otherwise be the dominant cost.
+            let topByIndex = Dictionary(uniqueKeysWithValues: offsets.blocks.map { ($0.index, $0.top) })
             return spans.enumerated().compactMap { offset, span -> BlockBand? in
-                guard let top = offsets.offset(forBlockIndex: span.index) else { return nil }
+                guard let top = topByIndex[span.index] else { return nil }
                 let y = top - textContainerOriginY
-                let nextTop = offset + 1 < spans.count
-                    ? offsets.offset(forBlockIndex: spans[offset + 1].index)
-                    : nil
+                let nextTop = offset + 1 < spans.count ? topByIndex[spans[offset + 1].index] : nil
                 let bottom = nextTop.map { $0 - textContainerOriginY } ?? totalHeight
                 return BlockBand(id: span.index, kind: span.kind, y: y, height: max(bottom - y, 0))
             }

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -39,19 +39,6 @@
     }
 
     extension PreviewDocumentMap {
-        /// Source index of the block containing `location`. Blocks are contiguous
-        /// spans, so a location on a span boundary belongs to the later block; a
-        /// location at or past the document end falls to the last block.
-        static func blockIndex(forLocation location: Int, in model: DocumentHeightModel) -> Int? {
-            for block in model.blocks where NSLocationInRange(location, block.range) {
-                return block.index
-            }
-            if let last = model.blocks.last, location >= last.range.location {
-                return last.index
-            }
-            return nil
-        }
-
         /// Build the map from positions alone — no live `NSTextView` — so the math is
         /// testable. `y` converts each block top from text-view space to scroll space
         /// by subtracting `textContainerOriginY`, the basis heading navigation uses.
@@ -76,7 +63,7 @@
                 )
             }
             let commentMarks = comments.compactMap { comment -> CommentMark? in
-                guard let blockIndex = blockIndex(forLocation: comment.range.location, in: blockModel),
+                guard let blockIndex = blockModel.blockIndex(containing: comment.range.location),
                       let top = offsets.offset(forBlockIndex: blockIndex)
                 else { return nil }
                 return CommentMark(

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -29,9 +29,6 @@
         /// The text view's real frame height — the denominator for normalizing a `y`
         /// onto a track, so marks track the actual scroller rather than the estimate.
         var totalHeight: CGFloat = 0
-        /// ``DocumentBlockOffsets/totalHeight`` — the semantic estimate, kept for
-        /// drift diagnostics; `totalHeight` is authoritative for normalization.
-        var estimatedTotalHeight: CGFloat = 0
         var viewportTop: CGFloat = 0
         var viewportHeight: CGFloat = 0
         var headings: [HeadingMark] = []
@@ -75,7 +72,6 @@
             }
             return PreviewDocumentMap(
                 totalHeight: totalHeight,
-                estimatedTotalHeight: offsets.totalHeight,
                 viewportTop: viewportTop,
                 viewportHeight: viewportHeight,
                 headings: headingMarks,

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -47,12 +47,14 @@
     }
 
     extension PreviewDocumentMap {
-        /// Build the map from positions alone — no live `NSTextView`. `y` converts
-        /// each block top from text-view space to scroll space by subtracting
-        /// `textContainerOriginY`, the basis heading navigation uses.
+        /// Build the map from positions alone — no live `NSTextView`. Heading `y`
+        /// converts each block top from text-view space to scroll space by subtracting
+        /// `textContainerOriginY`. Comment `y` arrives already in scroll space (the
+        /// coordinator measured it at intra-block precision via ``DocumentBlockOffsets/
+        /// characterY(at:in:model:textWidth:)``); here it's only paired with its block.
         static func build(
             headings: [HeadingNode],
-            comments: [(id: String, range: NSRange)],
+            comments: [(id: String, range: NSRange, y: CGFloat)],
             offsets: DocumentBlockOffsets,
             blockModel: DocumentHeightModel,
             textContainerOriginY: CGFloat,
@@ -71,14 +73,13 @@
                 )
             }
             let commentMarks = comments.compactMap { comment -> CommentMark? in
-                guard let blockIndex = blockModel.blockIndex(containing: comment.range.location),
-                      let top = offsets.offset(forBlockIndex: blockIndex)
+                guard let blockIndex = blockModel.blockIndex(containing: comment.range.location)
                 else { return nil }
                 return CommentMark(
                     id: comment.id,
                     range: comment.range,
                     blockIndex: blockIndex,
-                    y: top - textContainerOriginY
+                    y: comment.y
                 )
             }
             let blocks = blockBands(

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -129,5 +129,17 @@
             let height = min(max(viewportHeight / totalHeight, 0), 1 - top)
             return (top, height)
         }
+
+        /// The viewport thumb's `(height, offset)` on a track of `trackHeight`: the
+        /// height floored to `minHeight`, the offset clamped so the floored thumb stays
+        /// within the track. `nil` when there's no viewport to show. Shared by the
+        /// marker track and the minimap so the clamping can't drift between them.
+        func thumbMetrics(trackHeight: CGFloat, minHeight: CGFloat) -> (height: CGFloat, offset: CGFloat)? {
+            let viewport = normalizedViewport
+            guard viewport.height > 0 else { return nil }
+            let height = max(viewport.height * trackHeight, minHeight)
+            let offset = max(min(viewport.top * trackHeight, trackHeight - height), 0)
+            return (height, offset)
+        }
     }
 #endif

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -1,0 +1,114 @@
+#if os(macOS)
+    import AppKit
+
+    /// A heading's position on the preview's vertical extent, in scroll coordinates.
+    struct HeadingMark: Identifiable, Equatable {
+        let id: Int
+        let blockIndex: Int
+        let title: String
+        let level: Int
+        let y: CGFloat
+    }
+
+    /// A comment's position on the preview's vertical extent, in scroll coordinates.
+    /// `y` is the top of the comment's containing block (block granularity — exact
+    /// off-viewport, unlike `boundingRect`, which returns estimated frames there).
+    struct CommentMark: Identifiable, Equatable {
+        let id: String
+        let range: NSRange
+        let blockIndex: Int
+        let y: CGFloat
+    }
+
+    /// Heading, comment, and viewport positions within the preview's vertical
+    /// extent, all in scroll (clip-view) coordinates. The text-view coordinator
+    /// builds it from ``DocumentBlockOffsets`` once per content/width/scroll change;
+    /// the scroll-marker track (and later the minimap) consume it, so those views
+    /// never touch TextKit or the coordinate conversions.
+    struct PreviewDocumentMap: Equatable {
+        /// The text view's real frame height — the denominator for normalizing a `y`
+        /// onto a track, so marks track the actual scroller rather than the estimate.
+        var totalHeight: CGFloat = 0
+        /// ``DocumentBlockOffsets/totalHeight`` — the semantic estimate, kept for
+        /// drift diagnostics; `totalHeight` is authoritative for normalization.
+        var estimatedTotalHeight: CGFloat = 0
+        var viewportTop: CGFloat = 0
+        var viewportHeight: CGFloat = 0
+        var headings: [HeadingMark] = []
+        var comments: [CommentMark] = []
+    }
+
+    extension PreviewDocumentMap {
+        /// Source index of the block containing `location`. Blocks are contiguous
+        /// spans, so a location on a span boundary belongs to the later block; a
+        /// location at or past the document end falls to the last block.
+        static func blockIndex(forLocation location: Int, in model: DocumentHeightModel) -> Int? {
+            for block in model.blocks where NSLocationInRange(location, block.range) {
+                return block.index
+            }
+            if let last = model.blocks.last, location >= last.range.location {
+                return last.index
+            }
+            return nil
+        }
+
+        /// Build the map from positions alone — no live `NSTextView` — so the math is
+        /// testable. `y` converts each block top from text-view space to scroll space
+        /// by subtracting `textContainerOriginY`, the basis heading navigation uses.
+        static func build(
+            headings: [HeadingNode],
+            comments: [(id: String, range: NSRange)],
+            offsets: DocumentBlockOffsets,
+            blockModel: DocumentHeightModel,
+            textContainerOriginY: CGFloat,
+            totalHeight: CGFloat,
+            viewportTop: CGFloat,
+            viewportHeight: CGFloat
+        ) -> PreviewDocumentMap {
+            let headingMarks = headings.compactMap { heading -> HeadingMark? in
+                guard let top = offsets.offset(forBlockIndex: heading.blockIndex) else { return nil }
+                return HeadingMark(
+                    id: heading.id,
+                    blockIndex: heading.blockIndex,
+                    title: heading.title,
+                    level: heading.level,
+                    y: top - textContainerOriginY
+                )
+            }
+            let commentMarks = comments.compactMap { comment -> CommentMark? in
+                guard let blockIndex = blockIndex(forLocation: comment.range.location, in: blockModel),
+                      let top = offsets.offset(forBlockIndex: blockIndex)
+                else { return nil }
+                return CommentMark(
+                    id: comment.id,
+                    range: comment.range,
+                    blockIndex: blockIndex,
+                    y: top - textContainerOriginY
+                )
+            }
+            return PreviewDocumentMap(
+                totalHeight: totalHeight,
+                estimatedTotalHeight: offsets.totalHeight,
+                viewportTop: viewportTop,
+                viewportHeight: viewportHeight,
+                headings: headingMarks,
+                comments: commentMarks
+            )
+        }
+
+        /// `y` as a fraction in [0, 1] of the document height, for placing a mark on a track.
+        func normalized(_ y: CGFloat) -> CGFloat {
+            guard totalHeight > 0 else { return 0 }
+            return min(max(y / totalHeight, 0), 1)
+        }
+
+        /// The viewport as a normalized `(top, height)` fraction of the document, clamped
+        /// so the thumb stays within the track even when the viewport overhangs the end.
+        var normalizedViewport: (top: CGFloat, height: CGFloat) {
+            guard totalHeight > 0 else { return (0, 0) }
+            let top = min(max(viewportTop / totalHeight, 0), 1)
+            let height = min(max(viewportHeight / totalHeight, 0), 1 - top)
+            return (top, height)
+        }
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
+++ b/mkdn/Features/Viewer/Views/PreviewDocumentMap.swift
@@ -20,11 +20,21 @@
         let y: CGFloat
     }
 
-    /// Heading, comment, and viewport positions within the preview's vertical
-    /// extent, all in scroll (clip-view) coordinates. The text-view coordinator
-    /// builds it from ``DocumentBlockOffsets`` once per content/width/scroll change;
-    /// the scroll-marker track consumes it, so those views never touch TextKit or
-    /// the coordinate conversions.
+    /// A block's vertical extent on the preview, in scroll coordinates, for the
+    /// minimap's per-kind bands. `height` spans the gap to the next block's top;
+    /// the last block fills to the document bottom.
+    struct BlockBand: Identifiable, Equatable {
+        let id: Int // source block index
+        let kind: BlockKind
+        let y: CGFloat
+        let height: CGFloat
+    }
+
+    /// Heading, comment, block-band, and viewport positions within the preview's
+    /// vertical extent, all in scroll (clip-view) coordinates. The text-view
+    /// coordinator builds it from ``DocumentBlockOffsets`` once per content/width/
+    /// scroll change; the scroll-marker track and minimap consume it, so those views
+    /// never touch TextKit or the coordinate conversions.
     struct PreviewDocumentMap: Equatable {
         /// The text view's real frame height — the denominator for normalizing a `y`
         /// onto a track, so marks track the actual scroller rather than the estimate.
@@ -33,6 +43,7 @@
         var viewportHeight: CGFloat = 0
         var headings: [HeadingMark] = []
         var comments: [CommentMark] = []
+        var blocks: [BlockBand] = []
     }
 
     extension PreviewDocumentMap {
@@ -70,13 +81,39 @@
                     y: top - textContainerOriginY
                 )
             }
+            let blocks = blockBands(
+                blockModel: blockModel, offsets: offsets,
+                textContainerOriginY: textContainerOriginY, totalHeight: totalHeight
+            )
             return PreviewDocumentMap(
                 totalHeight: totalHeight,
                 viewportTop: viewportTop,
                 viewportHeight: viewportHeight,
                 headings: headingMarks,
-                comments: commentMarks
+                comments: commentMarks,
+                blocks: blocks
             )
+        }
+
+        /// Each block's scroll-space `[y, y+height)` extent, by kind, for the minimap.
+        /// `height` runs to the next block's top; the last block fills to `totalHeight`,
+        /// so the bands tile the full document with no gaps.
+        private static func blockBands(
+            blockModel: DocumentHeightModel,
+            offsets: DocumentBlockOffsets,
+            textContainerOriginY: CGFloat,
+            totalHeight: CGFloat
+        ) -> [BlockBand] {
+            let spans = blockModel.blocks
+            return spans.enumerated().compactMap { offset, span -> BlockBand? in
+                guard let top = offsets.offset(forBlockIndex: span.index) else { return nil }
+                let y = top - textContainerOriginY
+                let nextTop = offset + 1 < spans.count
+                    ? offsets.offset(forBlockIndex: spans[offset + 1].index)
+                    : nil
+                let bottom = nextTop.map { $0 - textContainerOriginY } ?? totalHeight
+                return BlockBand(id: span.index, kind: span.kind, y: y, height: max(bottom - y, 0))
+            }
         }
 
         /// `y` as a fraction in [0, 1] of the document height, for placing a mark on a track.

--- a/mkdn/Features/Viewer/Views/PreviewMapState.swift
+++ b/mkdn/Features/Viewer/Views/PreviewMapState.swift
@@ -1,0 +1,15 @@
+#if os(macOS)
+    import Foundation
+
+    /// Shared bridge between the preview's text-view coordinator and the sibling
+    /// scroll-marker track. The coordinator publishes ``documentMap`` (heading,
+    /// comment, and viewport positions in scroll space); the track renders from it
+    /// and calls ``scrollTo`` to jump the preview when a mark is clicked.
+    @MainActor @Observable
+    final class PreviewMapState {
+        var documentMap = PreviewDocumentMap()
+        /// Set by the coordinator; called by the track with a scroll-space y. Not
+        /// observed — the track invokes it on tap, it never drives a redraw.
+        @ObservationIgnored var scrollTo: ((CGFloat) -> Void)?
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
+++ b/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
@@ -3,9 +3,8 @@
 
     /// A slim vertical gutter beside the preview that plots heading and comment
     /// positions and the current viewport, read from ``PreviewMapState/documentMap``.
-    /// Heading ticks sit flush right (length and opacity by level); comment ticks sit
-    /// flush left in the accent color; a faint thumb tracks the viewport. A tap jumps
-    /// the preview to the nearest mark via ``PreviewMapState/scrollTo``.
+    /// Heading tick length and opacity encode level; a faint thumb tracks the viewport.
+    /// A tap jumps the preview to the nearest mark via ``PreviewMapState/scrollTo``.
     ///
     /// All positions arrive pre-converted to scroll space and normalized against the
     /// real document height, so the view never touches TextKit or coordinate math —

--- a/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
+++ b/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
@@ -48,10 +48,13 @@
         private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
             let viewport = map.normalizedViewport
             if viewport.height > 0 {
+                // Floor the height so a tiny viewport stays visible, then clamp the
+                // offset so that floor can't push the thumb past the track's bottom.
+                let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
                 RoundedRectangle(cornerRadius: 3)
                     .fill(colors.foreground.opacity(0.12))
-                    .frame(width: Self.width, height: max(viewport.height * height, Self.minThumbHeight))
-                    .offset(y: viewport.top * height)
+                    .frame(width: Self.width, height: thumbHeight)
+                    .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
             }
         }
 
@@ -74,12 +77,12 @@
         /// Jump to the mark nearest the tapped y; with no marks, scrub proportionally.
         private func jump(toTrackY tapY: CGFloat, trackHeight: CGFloat, map: PreviewDocumentMap) {
             guard trackHeight > 0, map.totalHeight > 0 else { return }
+            let tapFraction = tapY / trackHeight
             let markYs = map.headings.map(\.y) + map.comments.map(\.y)
             let nearest = markYs.min {
-                abs(map.normalized($0) * trackHeight - tapY)
-                    < abs(map.normalized($1) * trackHeight - tapY)
+                abs(map.normalized($0) - tapFraction) < abs(map.normalized($1) - tapFraction)
             }
-            state.scrollTo?(nearest ?? (tapY / trackHeight) * map.totalHeight)
+            state.scrollTo?(nearest ?? tapFraction * map.totalHeight)
         }
     }
 #endif

--- a/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
+++ b/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
@@ -1,0 +1,85 @@
+#if os(macOS)
+    import SwiftUI
+
+    /// A slim vertical gutter beside the preview that plots heading and comment
+    /// positions and the current viewport, read from ``PreviewMapState/documentMap``.
+    /// Heading ticks sit flush right (length and opacity by level); comment ticks sit
+    /// flush left in the accent color; a faint thumb tracks the viewport. A tap jumps
+    /// the preview to the nearest mark via ``PreviewMapState/scrollTo``.
+    ///
+    /// All positions arrive pre-converted to scroll space and normalized against the
+    /// real document height, so the view never touches TextKit or coordinate math —
+    /// it scales `documentMap` y-values by its own height.
+    struct ScrollMarkerTrack: View {
+        let state: PreviewMapState
+
+        @Environment(AppSettings.self) private var appSettings
+
+        static let width: CGFloat = 12
+        private static let minThumbHeight: CGFloat = 20
+
+        private var colors: ThemeColors { appSettings.theme.colors }
+
+        var body: some View {
+            let map = state.documentMap
+            GeometryReader { geo in
+                let height = geo.size.height
+                ZStack(alignment: .topLeading) {
+                    colors.background
+                    viewportThumb(map: map, height: height)
+                    ForEach(map.comments) { comment in
+                        commentTick(at: map.normalized(comment.y) * height)
+                    }
+                    ForEach(map.headings) { heading in
+                        headingTick(heading, at: map.normalized(heading.y) * height)
+                    }
+                }
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0).onEnded { value in
+                        jump(toTrackY: value.location.y, trackHeight: height, map: map)
+                    }
+                )
+            }
+            .frame(width: Self.width)
+        }
+
+        @ViewBuilder
+        private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
+            let viewport = map.normalizedViewport
+            if viewport.height > 0 {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(colors.foreground.opacity(0.12))
+                    .frame(width: Self.width, height: max(viewport.height * height, Self.minThumbHeight))
+                    .offset(y: viewport.top * height)
+            }
+        }
+
+        private func headingTick(_ heading: HeadingMark, at y: CGFloat) -> some View {
+            let length = max(9 - CGFloat(heading.level), 4)
+            return Rectangle()
+                .fill(colors.foreground.opacity(max(1 - CGFloat(heading.level) * 0.12, 0.4)))
+                .frame(width: length, height: 1.5)
+                .offset(x: Self.width - length, y: y - 0.75)
+                .help(heading.title)
+        }
+
+        private func commentTick(at y: CGFloat) -> some View {
+            Rectangle()
+                .fill(colors.accent)
+                .frame(width: 4, height: 1.5)
+                .offset(x: 0, y: y - 0.75)
+        }
+
+        /// Jump to the mark nearest the tapped y; with no marks, scrub proportionally.
+        private func jump(toTrackY tapY: CGFloat, trackHeight: CGFloat, map: PreviewDocumentMap) {
+            guard trackHeight > 0, map.totalHeight > 0 else { return }
+            let markYs = map.headings.map(\.y) + map.comments.map(\.y)
+            let nearest = markYs.min {
+                abs(map.normalized($0) * trackHeight - tapY)
+                    < abs(map.normalized($1) * trackHeight - tapY)
+            }
+            state.scrollTo?(nearest ?? (tapY / trackHeight) * map.totalHeight)
+        }
+    }
+#endif

--- a/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
+++ b/mkdn/Features/Viewer/Views/ScrollMarkerTrack.swift
@@ -45,15 +45,11 @@
 
         @ViewBuilder
         private func viewportThumb(map: PreviewDocumentMap, height: CGFloat) -> some View {
-            let viewport = map.normalizedViewport
-            if viewport.height > 0 {
-                // Floor the height so a tiny viewport stays visible, then clamp the
-                // offset so that floor can't push the thumb past the track's bottom.
-                let thumbHeight = max(viewport.height * height, Self.minThumbHeight)
+            if let thumb = map.thumbMetrics(trackHeight: height, minHeight: Self.minThumbHeight) {
                 RoundedRectangle(cornerRadius: 3)
                     .fill(colors.foreground.opacity(0.12))
-                    .frame(width: Self.width, height: thumbHeight)
-                    .offset(y: max(min(viewport.top * height, height - thumbHeight), 0))
+                    .frame(width: Self.width, height: thumb.height)
+                    .offset(y: thumb.offset)
             }
         }
 

--- a/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
+++ b/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
@@ -493,25 +493,18 @@
                 else { return false }
 
                 showHeadingDot(forCharacterOffset: charOffset)
-                scrollTo(scrollY: headingY, in: scrollView, animated: true)
+                scrollTo(scrollY: headingY, in: scrollView)
                 return true
             }
 
-            /// Scroll the clip view so document scroll-space `scrollY` sits at the
-            /// viewport top. Factored from ``scrollToHeading`` so any mark — a track
+            /// Smooth-scroll the clip view so document scroll-space `scrollY` sits at
+            /// the viewport top. Factored from ``scrollToHeading`` so any mark — a track
             /// tick, not just a heading — can target an arbitrary y. Suppresses scroll-
             /// spy for the duration so the programmatic move doesn't fight the breadcrumb.
-            func scrollTo(scrollY: CGFloat, in scrollView: NSScrollView, animated: Bool) {
+            func scrollTo(scrollY: CGFloat, in scrollView: NSScrollView) {
                 isProgrammaticScroll = true
                 let clipView = scrollView.contentView
                 let destination = NSPoint(x: 0, y: scrollY)
-                guard animated else {
-                    clipView.setBoundsOrigin(destination)
-                    scrollView.reflectScrolledClipView(clipView)
-                    isProgrammaticScroll = false
-                    handleScrollForSpy()
-                    return
-                }
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = AnimationConstants.scrollToHeadingDuration
                     context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
+++ b/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
@@ -29,6 +29,9 @@
             /// width and reused for heading navigation. Invalidated on content/width
             /// change (same as the heading cache). O(blocks^2) but one-shot.
             private var documentBlockOffsets: DocumentBlockOffsets?
+            /// Published heading/comment/viewport positions for the scroll-marker track.
+            weak var mapState: PreviewMapState?
+            private var mapRebuildScheduled = false
 
             // MARK: - Link Navigation
 
@@ -250,6 +253,7 @@
                 // rather than registering duplicates on the same notifications.
                 overlayCoordinator.onScrollChange = { [weak self] in
                     self?.handleScrollForSpy()
+                    self?.publishMapViewport()
                 }
                 overlayCoordinator.onFrameChange = { [weak self] in
                     guard let self else { return }
@@ -259,11 +263,14 @@
                     // heading can move. Scroll-spy is skipped mid-resize; re-run it once
                     // the resize settles (coalesced; it self-guards during the gesture).
                     scheduleScrollSpyRefresh()
+                    // Same rewrap moves every mark: rebuild the map at the new width.
+                    scheduleDocumentMapRebuild()
                 }
                 // A settle whose final layout posts no frame/scroll change would
                 // otherwise leave the spy unscheduled past the in-resize guard.
                 (textView as? CodeBlockBackgroundTextView)?.onResizeSettled = { [weak self] in
                     self?.scheduleScrollSpyRefresh()
+                    self?.scheduleDocumentMapRebuild()
                 }
             }
 
@@ -389,6 +396,63 @@
                 return offsets
             }
 
+            // MARK: - Document Map Publishing
+
+            /// Coalesced full rebuild of the document map. Scheduled (not run inline) so
+            /// a trigger from `updateNSView` doesn't mutate observable state mid-view-
+            /// update, and a burst of invalidations collapses to one rebuild.
+            func scheduleDocumentMapRebuild() {
+                guard !mapRebuildScheduled else { return }
+                mapRebuildScheduled = true
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    mapRebuildScheduled = false
+                    guard let map = buildDocumentMap() else { return }
+                    mapState?.documentMap = map
+                }
+            }
+
+            /// Viewport-only republish: the marks are width/content-keyed and don't move
+            /// on scroll, so reuse the published map and update just the viewport rect.
+            /// Skipped mid-resize/slide (the viewport is held) — the same guard as the
+            /// scroll-spy; the settle path triggers a full rebuild.
+            func publishMapViewport() {
+                guard let mapState,
+                      let textView = textView as? CodeBlockBackgroundTextView,
+                      let scrollView = textView.enclosingScrollView,
+                      textView.sidebarResizeAnchor == nil,
+                      !scrollView.inLiveResize
+                else { return }
+                let bounds = scrollView.contentView.bounds
+                var map = mapState.documentMap
+                guard map.viewportTop != bounds.origin.y || map.viewportHeight != bounds.height
+                else { return }
+                map.viewportTop = bounds.origin.y
+                map.viewportHeight = bounds.height
+                mapState.documentMap = map
+            }
+
+            private func buildDocumentMap() -> PreviewDocumentMap? {
+                guard let textView = textView as? CodeBlockBackgroundTextView,
+                      let outlineState,
+                      let model = documentHeightModel,
+                      let offsets = blockOffsets()
+                else { return nil }
+                let comments = (textView.resolvedComments?.active ?? [])
+                    .map { (id: $0.id, range: $0.range) }
+                let bounds = textView.enclosingScrollView?.contentView.bounds ?? .zero
+                return PreviewDocumentMap.build(
+                    headings: outlineState.flatHeadings,
+                    comments: comments,
+                    offsets: offsets,
+                    blockModel: model,
+                    textContainerOriginY: textView.textContainerOrigin.y,
+                    totalHeight: textView.frame.height,
+                    viewportTop: bounds.origin.y,
+                    viewportHeight: bounds.height
+                )
+            }
+
             /// Map a character offset in the text storage to a y-coordinate
             /// using the text layout manager.
             private func yPosition(forCharacterOffset offset: Int) -> CGFloat? {
@@ -428,10 +492,26 @@
                       let headingY = navigationY(forBlockIndex: blockIndex)
                 else { return false }
 
-                isProgrammaticScroll = true
                 showHeadingDot(forCharacterOffset: charOffset)
+                scrollTo(scrollY: headingY, in: scrollView, animated: true)
+                return true
+            }
+
+            /// Scroll the clip view so document scroll-space `scrollY` sits at the
+            /// viewport top. Factored from ``scrollToHeading`` so any mark — a track
+            /// tick, not just a heading — can target an arbitrary y. Suppresses scroll-
+            /// spy for the duration so the programmatic move doesn't fight the breadcrumb.
+            func scrollTo(scrollY: CGFloat, in scrollView: NSScrollView, animated: Bool) {
+                isProgrammaticScroll = true
                 let clipView = scrollView.contentView
-                let destination = NSPoint(x: 0, y: headingY)
+                let destination = NSPoint(x: 0, y: scrollY)
+                guard animated else {
+                    clipView.setBoundsOrigin(destination)
+                    scrollView.reflectScrolledClipView(clipView)
+                    isProgrammaticScroll = false
+                    handleScrollForSpy()
+                    return
+                }
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = AnimationConstants.scrollToHeadingDuration
                     context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
@@ -444,7 +524,6 @@
                         self?.handleScrollForSpy()
                     }
                 }
-                return true
             }
 
             /// Show a temporary accent dot in the left margin at the navigated heading.

--- a/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
+++ b/mkdn/Features/Viewer/Views/SelectableTextView+Coordinator.swift
@@ -436,17 +436,28 @@
                 guard let textView = textView as? CodeBlockBackgroundTextView,
                       let outlineState,
                       let model = documentHeightModel,
-                      let offsets = blockOffsets()
+                      let offsets = blockOffsets(),
+                      let textStorage = textView.textStorage
                 else { return nil }
-                let comments = (textView.resolvedComments?.active ?? [])
-                    .map { (id: $0.id, range: $0.range) }
+                let originY = textView.textContainerOrigin.y
+                // Measure each comment's y at intra-block precision (the line it sits on,
+                // not just its block top), then to scroll space — so a card anchors beside
+                // its own line and two comments in one paragraph don't stack on the top.
+                let comments: [(id: String, range: NSRange, y: CGFloat)] =
+                    (textView.resolvedComments?.active ?? []).compactMap { comment in
+                        guard let y = offsets.characterY(
+                            at: comment.range.location, in: textStorage,
+                            model: model, textWidth: textView.textWidth)
+                        else { return nil }
+                        return (id: comment.id, range: comment.range, y: y - originY)
+                    }
                 let bounds = textView.enclosingScrollView?.contentView.bounds ?? .zero
                 return PreviewDocumentMap.build(
                     headings: outlineState.flatHeadings,
                     comments: comments,
                     offsets: offsets,
                     blockModel: model,
-                    textContainerOriginY: textView.textContainerOrigin.y,
+                    textContainerOriginY: originY,
                     totalHeight: textView.frame.height,
                     viewportTop: bounds.origin.y,
                     viewportHeight: bounds.height

--- a/mkdn/Features/Viewer/Views/SelectableTextView.swift
+++ b/mkdn/Features/Viewer/Views/SelectableTextView.swift
@@ -37,6 +37,9 @@
         /// Bumped by the preview when only comments changed; swaps the resolved
         /// index and redraws — no storage edit, so the viewport never jumps.
         let commentRevision: Int
+        /// Shared with the scroll-marker track: the coordinator publishes positions
+        /// here and reads back the track's scroll-to requests.
+        let mapState: PreviewMapState
         @Binding var isLoadingGateActive: Bool
 
         // MARK: - NSViewRepresentable
@@ -68,6 +71,8 @@
                 // Same shift moves every block below the attachment: drop the heading
                 // position / offset cache so navigation re-measures at resolved heights.
                 coordinator.invalidateHeadingPositionCache()
+                // Resolved heights move every mark below the attachment too.
+                coordinator.scheduleDocumentMapRebuild()
                 guard !coordinator.gate.isGateActive else { return }
                 guard coordinator.animator.isAnimating else { return }
                 coordinator.animator.animateVisibleFragments()
@@ -82,6 +87,15 @@
             coordinator.outlineState = outlineState
             coordinator.headingOffsets = headingOffsets
             coordinator.documentHeightModel = documentHeightModel
+            coordinator.mapState = mapState
+            // The track calls this to jump the preview; resolve the scroll view at
+            // call time rather than capturing it, so a later rebuild can't strand it.
+            mapState.scrollTo = { [weak coordinator] scrollY in
+                guard let coordinator,
+                      let scrollView = coordinator.textView?.enclosingScrollView
+                else { return }
+                coordinator.scrollTo(scrollY: scrollY, in: scrollView, animated: true)
+            }
 
             applyTheme(to: textView, scrollView: scrollView)
             textView.findState = findState
@@ -101,6 +115,7 @@
             coordinator.lastAppliedText = attributedText
             coordinator.lastCommentRevision = commentRevision
             coordinator.wireScrollSpy()
+            coordinator.scheduleDocumentMapRebuild()
             RenderCompletionSignal.shared.signalRenderComplete()
 
             return scrollView
@@ -132,9 +147,12 @@
                 applyNewContent(
                     coordinator: coordinator, textView: textView, scrollView: scrollView
                 )
+                coordinator.scheduleDocumentMapRebuild()
             } else if coordinator.lastCommentRevision != commentRevision {
                 coordinator.lastCommentRevision = commentRevision
                 repaintCommentHighlights(textView: textView)
+                // Comment set changed: republish so comment marks track the edit.
+                coordinator.scheduleDocumentMapRebuild()
             }
 
             coordinator.handleFindUpdate(

--- a/mkdn/Features/Viewer/Views/SelectableTextView.swift
+++ b/mkdn/Features/Viewer/Views/SelectableTextView.swift
@@ -94,7 +94,7 @@
                 guard let coordinator,
                       let scrollView = coordinator.textView?.enclosingScrollView
                 else { return }
-                coordinator.scrollTo(scrollY: scrollY, in: scrollView, animated: true)
+                coordinator.scrollTo(scrollY: scrollY, in: scrollView)
             }
 
             applyTheme(to: textView, scrollView: scrollView)

--- a/mkdnTests/Unit/Core/DocumentBlockOffsetsTests.swift
+++ b/mkdnTests/Unit/Core/DocumentBlockOffsetsTests.swift
@@ -80,6 +80,18 @@
             // The refinement actually moved below the block-granular top (wrapped line).
             let blockTop = try #require(offsets.offset(forBlockIndex: 1))
             #expect(estimated > blockTop + 4)
+
+            // Line 2 of the code block: the prefix ends at an internal newline (the
+            // phantom line compute() corrects at boundaries) and the block carries
+            // code-padding spacing-before — both must not throw the measure off.
+            let codeLoc = text.range(of: "let b").location
+            try #require(codeLoc != NSNotFound)
+            let codeEstimated = try #require(offsets.characterY(
+                at: codeLoc, in: result.attributedString,
+                model: result.documentHeightModel, textWidth: textWidth))
+            let codeReal = try #require(textView.boundingRect(
+                forCharacterRange: NSRange(location: codeLoc, length: 1))?.minY)
+            #expect(abs(codeEstimated - codeReal) < 6)
         }
 
         @Test("blockIndex(atY:) maps a y back to the block that contains it")

--- a/mkdnTests/Unit/Core/DocumentBlockOffsetsTests.swift
+++ b/mkdnTests/Unit/Core/DocumentBlockOffsetsTests.swift
@@ -52,6 +52,36 @@
             }
         }
 
+        @Test("characterY tracks the real line top of a character inside a block",
+              arguments: [380.0, 620.0])
+        @MainActor func characterYTracksRealLineTop(viewWidth: CGFloat) throws {
+            let result = MarkdownTextStorageBuilder.build(blocks: mixedBlocks(), theme: .solarizedDark)
+            let (textView, window, textWidth) =
+                LayoutMeasurementHarness.layOut(result.attributedString, viewWidth: viewWidth)
+            _ = window
+            let offsets = DocumentBlockOffsets.compute(
+                of: result.attributedString, model: result.documentHeightModel,
+                textWidth: textWidth, verticalInset: 32)
+
+            // A phrase well into the wrapping first paragraph, so its line sits below
+            // the block top — the intra-block refinement has to find it.
+            let text = result.attributedString.string as NSString
+            let location = text.range(of: "these tests").location
+            try #require(location != NSNotFound)
+            let estimated = try #require(offsets.characterY(
+                at: location, in: result.attributedString,
+                model: result.documentHeightModel, textWidth: textWidth))
+            let real = try #require(textView.boundingRect(
+                forCharacterRange: NSRange(location: location, length: 1))?.minY)
+            // Lands within one line of the real line top, biased low (a card never
+            // floats above its comment): real <= estimated <= real + ~1 line.
+            #expect(estimated >= real - 4)
+            #expect(estimated - real < 26)
+            // The refinement actually moved below the block-granular top (wrapped line).
+            let blockTop = try #require(offsets.offset(forBlockIndex: 1))
+            #expect(estimated > blockTop + 4)
+        }
+
         @Test("blockIndex(atY:) maps a y back to the block that contains it")
         @MainActor func yMapsToBlock() {
             let result = MarkdownTextStorageBuilder.build(blocks: mixedBlocks(), theme: .solarizedDark)

--- a/mkdnTests/Unit/Features/AnchoredCommentPlacementTests.swift
+++ b/mkdnTests/Unit/Features/AnchoredCommentPlacementTests.swift
@@ -1,0 +1,42 @@
+#if os(macOS)
+    import Testing
+    @testable import mkdnLib
+
+    @Suite("AnchoredCommentPlacement")
+    struct AnchoredCommentPlacementTests {
+        @Test("Non-overlapping cards keep their anchors")
+        func noCollision() {
+            let tops = AnchoredCommentPlacement.tops(anchors: [0, 100, 300], heights: [40, 40, 40], gap: 8)
+            #expect(tops == [0, 100, 300])
+        }
+
+        @Test("Cards sharing an anchor stack with a gap")
+        func sameAnchorStacks() {
+            let tops = AnchoredCommentPlacement.tops(anchors: [100, 100, 100], heights: [20, 20, 20], gap: 5)
+            #expect(tops == [100, 125, 150])
+        }
+
+        @Test("An off-screen-above card keeps its negative top — no jump into view")
+        func offscreenAbove() {
+            let tops = AnchoredCommentPlacement.tops(anchors: [-50, 10], heights: [30, 20], gap: 5)
+            #expect(tops == [-50, 10])
+        }
+
+        @Test("Collision still pushes down while both cards are above the viewport")
+        func collisionAboveViewport() {
+            let tops = AnchoredCommentPlacement.tops(anchors: [-50, -40], heights: [30, 20], gap: 5)
+            #expect(tops == [-50, -15]) // second dropped to -50 + 30 + 5
+        }
+
+        @Test("A dense cluster cascades past the bottom; clipping absorbs the overflow")
+        func bottomOverflow() {
+            let tops = AnchoredCommentPlacement.tops(anchors: [500, 500, 500], heights: [40, 40, 40], gap: 8)
+            #expect(tops == [500, 548, 596])
+        }
+
+        @Test("Empty input yields no tops")
+        func empty() {
+            #expect(AnchoredCommentPlacement.tops(anchors: [], heights: [], gap: 8).isEmpty)
+        }
+    }
+#endif

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -95,6 +95,40 @@
             #expect(map.comments.map(\.y) == [0, 100, 300, 300])
         }
 
+        // MARK: - block bands
+
+        @Test("Block bands tile the document by kind; the last fills to totalHeight")
+        func buildBlockBands() {
+            let kinded = DocumentHeightModel(blocks: [
+                BlockSpan(index: 0, range: NSRange(location: 0, length: 10), kind: .heading(level: 1)),
+                BlockSpan(index: 1, range: NSRange(location: 10, length: 20), kind: .code),
+                BlockSpan(index: 2, range: NSRange(location: 30, length: 15), kind: .table),
+            ])
+            let map = PreviewDocumentMap.build(
+                headings: [], comments: [], offsets: offsets, blockModel: kinded,
+                textContainerOriginY: originY, totalHeight: 480, viewportTop: 0, viewportHeight: 100
+            )
+            #expect(map.blocks.map(\.id) == [0, 1, 2])
+            #expect(map.blocks.map(\.kind) == [.heading(level: 1), .code, .table])
+            #expect(map.blocks.map(\.y) == [0, 100, 300]) // tops in scroll space
+            #expect(map.blocks.map(\.height) == [100, 200, 180]) // last fills 480-300
+        }
+
+        @Test("MarkdownBlock.blockKind folds the renderer cases into minimap kinds")
+        func blockKindMapping() {
+            #expect(MarkdownBlock.heading(level: 2, text: AttributedString("H")).blockKind == .heading(level: 2))
+            #expect(MarkdownBlock.paragraph(text: AttributedString("p")).blockKind == .paragraph)
+            #expect(MarkdownBlock.codeBlock(language: nil, code: "x").blockKind == .code)
+            #expect(MarkdownBlock.htmlBlock(content: "<b>").blockKind == .code)
+            #expect(MarkdownBlock.image(source: "a", alt: "").blockKind == .image)
+            #expect(MarkdownBlock.mermaidBlock(code: "g").blockKind == .image)
+            #expect(MarkdownBlock.orderedList(items: []).blockKind == .list)
+            #expect(MarkdownBlock.blockquote(blocks: []).blockKind == .blockquote)
+            #expect(MarkdownBlock.table(columns: [], rows: []).blockKind == .table)
+            #expect(MarkdownBlock.mathBlock(code: "x").blockKind == .math)
+            #expect(MarkdownBlock.thematicBreak.blockKind == .divider)
+        }
+
         // MARK: - normalization
 
         @Test("normalized maps y onto [0, 1] and clamps")

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -22,32 +22,32 @@
         )
         private let originY: CGFloat = 32
 
-        // MARK: - blockIndex(forLocation:)
+        // MARK: - DocumentHeightModel.blockIndex(containing:)
 
         @Test("Location resolves to its containing block")
         func locationInsideBlocks() {
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 5, in: model) == 0)
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 20, in: model) == 1)
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 44, in: model) == 2)
+            #expect(model.blockIndex(containing: 5) == 0)
+            #expect(model.blockIndex(containing: 20) == 1)
+            #expect(model.blockIndex(containing: 44) == 2)
         }
 
         @Test("A boundary location belongs to the later block")
         func locationOnBoundary() {
             // 10 ends block 0 and starts block 1; 30 ends block 1 and starts block 2.
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 10, in: model) == 1)
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 30, in: model) == 2)
+            #expect(model.blockIndex(containing: 10) == 1)
+            #expect(model.blockIndex(containing: 30) == 2)
         }
 
         @Test("A location at or past the end falls to the last block")
         func locationAtEnd() {
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 45, in: model) == 2)
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 99, in: model) == 2)
+            #expect(model.blockIndex(containing: 45) == 2)
+            #expect(model.blockIndex(containing: 99) == 2)
         }
 
         @Test("An empty model resolves no block")
         func emptyModel() {
             let empty = DocumentHeightModel(blocks: [])
-            #expect(PreviewDocumentMap.blockIndex(forLocation: 0, in: empty) == nil)
+            #expect(empty.blockIndex(containing: 0) == nil)
         }
 
         // MARK: - build

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -78,13 +78,15 @@
             #expect(map.headings.isEmpty)
         }
 
-        @Test("Comments map through their containing block to scroll-space y")
+        @Test("Comments carry their precomputed y and resolve their containing block")
         func buildComments() {
-            let comments: [(id: String, range: NSRange)] = [
-                (id: "a", range: NSRange(location: 5, length: 3)),   // block 0 -> y 0
-                (id: "b", range: NSRange(location: 10, length: 1)),  // boundary -> block 1 -> y 100
-                (id: "c", range: NSRange(location: 35, length: 2)),  // block 2 -> y 300
-                (id: "d", range: NSRange(location: 45, length: 0)),  // end -> block 2 -> y 300
+            // y is the coordinator's intra-block measure (tested in DocumentBlockOffsets);
+            // build pairs each comment with its block and passes the y straight through.
+            let comments: [(id: String, range: NSRange, y: CGFloat)] = [
+                (id: "a", range: NSRange(location: 5, length: 3), y: 12),   // block 0
+                (id: "b", range: NSRange(location: 10, length: 1), y: 108), // boundary -> block 1
+                (id: "c", range: NSRange(location: 35, length: 2), y: 305), // block 2
+                (id: "d", range: NSRange(location: 45, length: 0), y: 410), // end -> block 2
             ]
             let map = PreviewDocumentMap.build(
                 headings: [], comments: comments, offsets: offsets, blockModel: model,
@@ -92,7 +94,7 @@
             )
             #expect(map.comments.map(\.id) == ["a", "b", "c", "d"])
             #expect(map.comments.map(\.blockIndex) == [0, 1, 2, 2])
-            #expect(map.comments.map(\.y) == [0, 100, 300, 300])
+            #expect(map.comments.map(\.y) == [12, 108, 305, 410]) // passed through, not block tops
         }
 
         // MARK: - block bands

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -65,7 +65,6 @@
             #expect(map.headings.map(\.y) == [0, 300]) // 32-32, 332-32
             #expect(map.headings.map(\.level) == [1, 2])
             #expect(map.headings.map(\.title) == ["Intro", "Details"])
-            #expect(map.estimatedTotalHeight == 500)
             #expect(map.totalHeight == 480)
         }
 

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -1,0 +1,124 @@
+#if os(macOS)
+    import AppKit
+    import Testing
+    @testable import mkdnLib
+
+    @Suite("PreviewDocumentMap")
+    struct PreviewDocumentMapTests {
+        // Three contiguous blocks spanning [0,10) [10,30) [30,45); length 45.
+        private let model = DocumentHeightModel(blocks: [
+            BlockSpan(index: 0, range: NSRange(location: 0, length: 10)),
+            BlockSpan(index: 1, range: NSRange(location: 10, length: 20)),
+            BlockSpan(index: 2, range: NSRange(location: 30, length: 15)),
+        ])
+        // Block tops in text-view space; scroll-space y = top - originY (32 below).
+        private let offsets = DocumentBlockOffsets(
+            blocks: [
+                BlockOffset(index: 0, top: 32),
+                BlockOffset(index: 1, top: 132),
+                BlockOffset(index: 2, top: 332),
+            ],
+            totalHeight: 500
+        )
+        private let originY: CGFloat = 32
+
+        // MARK: - blockIndex(forLocation:)
+
+        @Test("Location resolves to its containing block")
+        func locationInsideBlocks() {
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 5, in: model) == 0)
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 20, in: model) == 1)
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 44, in: model) == 2)
+        }
+
+        @Test("A boundary location belongs to the later block")
+        func locationOnBoundary() {
+            // 10 ends block 0 and starts block 1; 30 ends block 1 and starts block 2.
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 10, in: model) == 1)
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 30, in: model) == 2)
+        }
+
+        @Test("A location at or past the end falls to the last block")
+        func locationAtEnd() {
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 45, in: model) == 2)
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 99, in: model) == 2)
+        }
+
+        @Test("An empty model resolves no block")
+        func emptyModel() {
+            let empty = DocumentHeightModel(blocks: [])
+            #expect(PreviewDocumentMap.blockIndex(forLocation: 0, in: empty) == nil)
+        }
+
+        // MARK: - build
+
+        @Test("Headings convert block tops to scroll-space y")
+        func buildHeadings() {
+            let headings = [
+                HeadingNode(id: 0, title: "Intro", level: 1, blockIndex: 0),
+                HeadingNode(id: 2, title: "Details", level: 2, blockIndex: 2),
+            ]
+            let map = PreviewDocumentMap.build(
+                headings: headings, comments: [], offsets: offsets, blockModel: model,
+                textContainerOriginY: originY, totalHeight: 480, viewportTop: 0, viewportHeight: 100
+            )
+            #expect(map.headings.map(\.y) == [0, 300]) // 32-32, 332-32
+            #expect(map.headings.map(\.level) == [1, 2])
+            #expect(map.headings.map(\.title) == ["Intro", "Details"])
+            #expect(map.estimatedTotalHeight == 500)
+            #expect(map.totalHeight == 480)
+        }
+
+        @Test("A heading whose block has no offset is dropped")
+        func buildHeadingMissingOffset() {
+            let headings = [HeadingNode(id: 9, title: "Ghost", level: 1, blockIndex: 9)]
+            let map = PreviewDocumentMap.build(
+                headings: headings, comments: [], offsets: offsets, blockModel: model,
+                textContainerOriginY: originY, totalHeight: 480, viewportTop: 0, viewportHeight: 100
+            )
+            #expect(map.headings.isEmpty)
+        }
+
+        @Test("Comments map through their containing block to scroll-space y")
+        func buildComments() {
+            let comments: [(id: String, range: NSRange)] = [
+                (id: "a", range: NSRange(location: 5, length: 3)),   // block 0 -> y 0
+                (id: "b", range: NSRange(location: 10, length: 1)),  // boundary -> block 1 -> y 100
+                (id: "c", range: NSRange(location: 35, length: 2)),  // block 2 -> y 300
+                (id: "d", range: NSRange(location: 45, length: 0)),  // end -> block 2 -> y 300
+            ]
+            let map = PreviewDocumentMap.build(
+                headings: [], comments: comments, offsets: offsets, blockModel: model,
+                textContainerOriginY: originY, totalHeight: 480, viewportTop: 0, viewportHeight: 100
+            )
+            #expect(map.comments.map(\.id) == ["a", "b", "c", "d"])
+            #expect(map.comments.map(\.blockIndex) == [0, 1, 2, 2])
+            #expect(map.comments.map(\.y) == [0, 100, 300, 300])
+        }
+
+        // MARK: - normalization
+
+        @Test("normalized maps y onto [0, 1] and clamps")
+        func normalized() {
+            let map = PreviewDocumentMap(totalHeight: 400)
+            #expect(abs(map.normalized(100) - 0.25) < 1e-9)
+            #expect(map.normalized(-50) == 0)
+            #expect(map.normalized(800) == 1)
+            #expect(PreviewDocumentMap(totalHeight: 0).normalized(100) == 0)
+        }
+
+        @Test("normalizedViewport is a clamped (top, height) fraction")
+        func normalizedViewport() {
+            let inside = PreviewDocumentMap(totalHeight: 400, viewportTop: 100, viewportHeight: 200)
+            #expect(abs(inside.normalizedViewport.top - 0.25) < 1e-9)
+            #expect(abs(inside.normalizedViewport.height - 0.5) < 1e-9)
+
+            // Viewport overhanging the end: height clamps so the thumb stays in the track.
+            let overhang = PreviewDocumentMap(totalHeight: 400, viewportTop: 360, viewportHeight: 200)
+            #expect(abs(overhang.normalizedViewport.top - 0.9) < 1e-9)
+            #expect(abs(overhang.normalizedViewport.height - 0.1) < 1e-9)
+
+            #expect(PreviewDocumentMap(totalHeight: 0).normalizedViewport.height == 0)
+        }
+    }
+#endif

--- a/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
+++ b/mkdnTests/Unit/Features/PreviewDocumentMapTests.swift
@@ -153,5 +153,23 @@
 
             #expect(PreviewDocumentMap(totalHeight: 0).normalizedViewport.height == 0)
         }
+
+        @Test("thumbMetrics floors the height and clamps the offset into the track")
+        func thumbMetrics() {
+            let map = PreviewDocumentMap(totalHeight: 400, viewportTop: 100, viewportHeight: 200)
+            let metrics = map.thumbMetrics(trackHeight: 100, minHeight: 20)
+            #expect(metrics?.height == 50) // 0.5 * 100
+            #expect(metrics?.offset == 25) // 0.25 * 100
+
+            // A tiny viewport floors to minHeight; the offset clamps so the thumb's
+            // bottom stays at the track end (90 would overhang past 100-20).
+            let tiny = PreviewDocumentMap(totalHeight: 1000, viewportTop: 900, viewportHeight: 10)
+            let clamped = tiny.thumbMetrics(trackHeight: 100, minHeight: 20)
+            #expect(clamped?.height == 20)
+            #expect(clamped?.offset == 80)
+
+            // No viewport to show -> nil.
+            #expect(PreviewDocumentMap(totalHeight: 0).thumbMetrics(trackHeight: 100, minHeight: 20) == nil)
+        }
     }
 #endif

--- a/scripts/mkdn-ctl
+++ b/scripts/mkdn-ctl
@@ -83,6 +83,8 @@ def main():
             r = send(sock, {"addComment": {"substring": sys.argv[2], "body": body}})
         elif cmd_name == "toggle-comments":
             r = send(sock, {"toggleCommentSidebar": {}})
+        elif cmd_name == "toggle-minimap":
+            r = send(sock, {"toggleMinimap": {}})
         elif cmd_name == "jump-first-comment":
             r = send(sock, {"jumpFirstComment": {}})
         elif cmd_name == "jump-comment-at":


### PR DESCRIPTION
Wires the Phase-3 `DocumentBlockOffsets` height primitive into **all three visual consumers**, plus an intra-block precision pass. Each phase was built via crew flow and review-closed (`/code-review` + codex). Baseline 804 tests → **823 green**, build clean (warnings-as-errors).

## What's in it

**Phase 4.1 — Scroll-marker track.** A slim 12pt gutter plotting heading ticks (length/opacity by level), comment ticks, and a viewport thumb, read from a shared `PreviewDocumentMap`/`PreviewMapState`. Tap → nearest mark. Coordinate basis is scroll-space; the thumb denominator is the real frame height.

**Phase 4.2 — Document minimap.** A toggleable 64pt panel (Cmd+Shift+M, swaps in for the track) drawing per-block colored **bands by kind** (`BlockKind`: headings strong, embedded content in accent, body receding) + comment dots + viewport thumb. Tap scrolls proportionally.

**Phase 4.3 — Anchored comment cards (Google-Docs-style).** Comment cards float beside the text they annotate and follow it on scroll, via a custom SwiftUI `Layout` with per-card anchors (`LayoutValueKey`), downward-only collision (pure, tested), a floating opaque header, and a detached footer.

**Phase 4.4 — Intra-block comment-y precision.** `DocumentBlockOffsets.characterY` refines the block-granular top to the line a comment sits on (same Core Text prefix measure `compute` uses, no TextKit layout), biased low so a card never floats above its comment. Oracle-tested vs real `boundingRect` line tops, including a code-block case (<6px).

## Notes

- Shared infra: `PreviewDocumentMap` (pure, ~12 tests) + `PreviewMapState` (`@Observable` bridge); coordinator publishes on the existing scroll/frame/content hooks, viewport-only fast path on scroll.
- A codex specialist consult root-caused the test-harness comment orphaning (stale fixture selectors missing per-entry `norm`), unblocking visual verification of every comment feature; `marker-track-test.md` and `comments-test.md` fixtures fixed + a `toggleMinimap` harness command added.
- Visually verified both Solarized themes for every rendering change.
- Known low-priority follow-up: dense-cluster-at-document-end card reachability (clipped cards, no sidebar scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
