### PR TITLE
Comment cards: document-end reachability + oldest-on-top ordering

### DIFF
--- a/mkdn/Core/Markdown/ResolvedComments.swift
+++ b/mkdn/Core/Markdown/ResolvedComments.swift
@@ -8,6 +8,9 @@
     struct ResolvedComments: Equatable {
         private let index: CommentAnchorResolver.Index
         private let entriesByID: [String: CommentSidecar.Entry]
+        /// id → position in the sidecar (creation order, oldest first). Comment ids are
+        /// random, so this is what orders comments that share an anchor.
+        private let creationOrder: [String: Int]
 
         static func resolve(_ entries: [CommentSidecar.Entry], in tape: AnchorTape) -> ResolvedComments {
             // The sidecar is user-editable, so guard against duplicate ids: keep the
@@ -17,7 +20,8 @@
             let unique = entries.filter { seen.insert($0.id).inserted }
             let index = CommentAnchorResolver.resolveAll(unique, in: tape)
             let byID = Dictionary(uniqueKeysWithValues: unique.map { ($0.id, $0) })
-            return ResolvedComments(index: index, entriesByID: byID)
+            let order = Dictionary(uniqueKeysWithValues: unique.enumerated().map { ($0.element.id, $0.offset) })
+            return ResolvedComments(index: index, entriesByID: byID, creationOrder: order)
         }
 
         /// Resolved highlight ranges keyed by comment id, for the overlay draw.
@@ -42,13 +46,17 @@
             .sorted { $0.range.length < $1.range.length }
         }
 
-        /// Resolved comments in document order (by range location, ties broken by
-        /// id for stability), for the sidebar's "On this page" list.
+        /// Resolved comments in document order (by range location), ties broken by
+        /// creation order — oldest first — so comments sharing an anchor read top-down
+        /// as a thread. Drives the sidebar's anchored cards and the gutter marks.
         var active: [(id: String, entry: CommentSidecar.Entry, range: NSRange)] {
             index.ranges.compactMap { id, range in
                 entriesByID[id].map { (id: id, entry: $0, range: range) }
             }
-            .sorted { ($0.range.location, $0.id) < ($1.range.location, $1.id) }
+            .sorted {
+                ($0.range.location, creationOrder[$0.id] ?? .max)
+                    < ($1.range.location, creationOrder[$1.id] ?? .max)
+            }
         }
 
         /// Entries whose anchor couldn't be located, for the orphan sidebar.

--- a/mkdn/Features/Viewer/Views/AnchoredCommentPlacement.swift
+++ b/mkdn/Features/Viewer/Views/AnchoredCommentPlacement.swift
@@ -12,7 +12,21 @@
     /// view and shoving the rest down.
     enum AnchoredCommentPlacement {
         /// `anchors` and `heights` are parallel, in document (top-down) order.
-        static func tops(anchors: [CGFloat], heights: [CGFloat], gap: CGFloat) -> [CGFloat] {
+        ///
+        /// `visibleBottom`/`fitBottomOverflow`: at the document's scroll end, cards can
+        /// no longer be pulled into view by scrolling, so a dense tail that cascades past
+        /// the panel bottom would be unreachable. When `fitBottomOverflow` is on and the
+        /// last card overflows `visibleBottom`, a reverse pass lifts just the overflowing
+        /// suffix up to fit — stopping the moment an earlier card no longer collides, so
+        /// the anchored cards above keep their place. Off mid-document, where the tail is
+        /// meant to be below the panel and reachable by scrolling.
+        static func tops(
+            anchors: [CGFloat],
+            heights: [CGFloat],
+            gap: CGFloat,
+            visibleBottom: CGFloat? = nil,
+            fitBottomOverflow: Bool = false
+        ) -> [CGFloat] {
             var tops: [CGFloat] = []
             tops.reserveCapacity(anchors.count)
             var cursor = -CGFloat.greatestFiniteMagnitude
@@ -21,6 +35,19 @@
                 tops.append(top)
                 let height = index < heights.count ? heights[index] : 0
                 cursor = top + height + gap
+            }
+
+            guard fitBottomOverflow, let visibleBottom, let last = tops.indices.last
+            else { return tops }
+            let lastHeight = last < heights.count ? heights[last] : 0
+            guard tops[last] + lastHeight > visibleBottom else { return tops }
+            var fitCursor = visibleBottom
+            for index in tops.indices.reversed() {
+                let height = index < heights.count ? heights[index] : 0
+                let maxTop = fitCursor - height
+                guard tops[index] > maxTop else { break }
+                tops[index] = maxTop
+                fitCursor = maxTop - gap
             }
             return tops
         }

--- a/mkdn/Features/Viewer/Views/AnchoredCommentsLayout.swift
+++ b/mkdn/Features/Viewer/Views/AnchoredCommentsLayout.swift
@@ -18,8 +18,13 @@
     /// (``AnchoredCommentPlacement``), filling the container so an off-screen card
     /// clips out rather than reflowing the rest. The cards follow the document
     /// because the host recomputes each anchor from the live `viewportTop`.
+    ///
+    /// `atDocumentEnd` lets a dense tail that overflows the panel bottom fit back into
+    /// view (see ``AnchoredCommentPlacement``); the host sets it when the document is
+    /// scrolled to its end, where the tail can't otherwise be reached.
     struct AnchoredCommentsLayout: Layout {
         var gap: CGFloat = 8
+        var atDocumentEnd: Bool = false
 
         func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
             proposal.replacingUnspecifiedDimensions()
@@ -31,7 +36,9 @@
             let cardProposal = ProposedViewSize(width: bounds.width, height: nil)
             let anchors = subviews.map { $0[CommentCardAnchor.self] }
             let heights = subviews.map { $0.sizeThatFits(cardProposal).height }
-            let tops = AnchoredCommentPlacement.tops(anchors: anchors, heights: heights, gap: gap)
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: anchors, heights: heights, gap: gap,
+                visibleBottom: bounds.height, fitBottomOverflow: atDocumentEnd)
             for (index, subview) in subviews.enumerated() {
                 subview.place(
                     at: CGPoint(x: bounds.minX, y: bounds.minY + tops[index]),

--- a/mkdn/Features/Viewer/Views/CommentSidebarView.swift
+++ b/mkdn/Features/Viewer/Views/CommentSidebarView.swift
@@ -43,6 +43,10 @@
                 map.comments.map { ($0.id, $0.y - map.viewportTop + Self.previewTopInset) },
                 uniquingKeysWith: { first, _ in first }
             )
+            // At the scroll end a card tail can't be pulled up by scrolling; let the
+            // layout fit the overflow then. A short/unscrollable document reads as "end".
+            let atDocumentEnd = map.totalHeight > 0
+                && map.viewportTop + map.viewportHeight >= map.totalHeight - 1
             ZStack(alignment: .top) {
                 // Cards fill the space above the footer (not under it): the footer is
                 // opaque, so an overlapping ZStack sibling would occlude bottom cards.
@@ -50,7 +54,7 @@
                     if active.isEmpty, detached.isEmpty {
                         emptyState
                     } else {
-                        anchoredActiveCards(tops: cardTops)
+                        anchoredActiveCards(tops: cardTops, atDocumentEnd: atDocumentEnd)
                     }
                     if !detached.isEmpty {
                         detachedFooter
@@ -67,8 +71,8 @@
         /// Active cards anchored beside their text, clipped to the panel. No implicit
         /// animation: the per-frame reposition from the live `viewportTop` is the
         /// scroll-follow, so animating it would lag the text.
-        private func anchoredActiveCards(tops: [String: CGFloat]) -> some View {
-            AnchoredCommentsLayout(gap: 8) {
+        private func anchoredActiveCards(tops: [String: CGFloat], atDocumentEnd: Bool) -> some View {
+            AnchoredCommentsLayout(gap: 8, atDocumentEnd: atDocumentEnd) {
                 ForEach(active) { item in
                     ActiveCommentCard(item: item, theme: theme, onJump: onJump, onHover: onHover)
                         .commentCardAnchor(tops[item.id] ?? 0)

--- a/mkdnTests/Unit/Core/ResolvedCommentsTests.swift
+++ b/mkdnTests/Unit/Core/ResolvedCommentsTests.swift
@@ -56,15 +56,16 @@
             #expect(active.map(\.range) == [NSRange(location: 4, length: 5), NSRange(location: 16, length: 3)])
         }
 
-        @Test("active breaks location ties by id for stable ordering")
+        @Test("active breaks location ties by creation order — oldest on top")
         func activeTieBreak() {
-            // Two distinct comments resolving to the same location (identical quote)
-            // must order deterministically by id.
+            // Two distinct comments resolving to the same location (identical quote):
+            // ids are random, so they order by sidecar position (oldest first), reading
+            // top-down as a thread. "z" is recorded first, so it stays on top of "a".
             let resolved = ResolvedComments.resolve(
                 [entry("z", quote: "quick"), entry("a", quote: "quick")],
                 in: tape("the quick brown fox")
             )
-            #expect(resolved.active.map(\.id) == ["a", "z"])
+            #expect(resolved.active.map(\.id) == ["z", "a"])
         }
 
         @Test("Duplicate ids keep the first entry; resolved and orphaned stay disjoint")

--- a/mkdnTests/Unit/Features/AnchoredCommentPlacementTests.swift
+++ b/mkdnTests/Unit/Features/AnchoredCommentPlacementTests.swift
@@ -38,5 +38,47 @@
         func empty() {
             #expect(AnchoredCommentPlacement.tops(anchors: [], heights: [], gap: 8).isEmpty)
         }
+
+        // MARK: - fitBottomOverflow (document-end reachability)
+
+        @Test("fitBottomOverflow leaves a tail that already fits untouched")
+        func fitNoOverflow() {
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: [0, 100, 200], heights: [40, 40, 40], gap: 8,
+                visibleBottom: 600, fitBottomOverflow: true)
+            #expect(tops == [0, 100, 200])
+        }
+
+        @Test("A dense tail at the document end is lifted up to fit the panel")
+        func fitDenseTail() {
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: [500, 500, 500], heights: [40, 40, 40], gap: 8,
+                visibleBottom: 600, fitBottomOverflow: true)
+            #expect(tops == [464, 512, 560]) // bottom card ends at 600
+        }
+
+        @Test("Fitting the tail leaves earlier anchored cards in place")
+        func fitKeepsEarlierCards() {
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: [100, 500, 500, 500], heights: [40, 40, 40, 40], gap: 8,
+                visibleBottom: 600, fitBottomOverflow: true)
+            #expect(tops == [100, 464, 512, 560]) // the 100 card is undisturbed
+        }
+
+        @Test("Fitting the tail leaves an above-viewport card above")
+        func fitKeepsAboveCard() {
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: [-100, 500, 500, 500], heights: [40, 40, 40, 40], gap: 8,
+                visibleBottom: 600, fitBottomOverflow: true)
+            #expect(tops == [-100, 464, 512, 560])
+        }
+
+        @Test("A card taller than the panel pins its bottom into view")
+        func fitOversizedCard() {
+            let tops = AnchoredCommentPlacement.tops(
+                anchors: [100], heights: [700], gap: 8,
+                visibleBottom: 600, fitBottomOverflow: true)
+            #expect(tops == [-100]) // bottom at 600; top clips above
+        }
     }
 #endif


### PR DESCRIPTION
Two finishing touches to the anchored comment cards (follow-ups to PR #10), each codex-consulted and review-closed.

## Document-end card reachability
When a dense cluster of comments sat near the document **end**, the downward collision cascade pushed the tail below the clipped, non-scrolling sidebar panel — and since the document can't scroll past its end, those cards were unreachable. Codex designed the fix: at the scroll end, a reverse pass in the pure `AnchoredCommentPlacement.tops` lifts only the overflowing suffix up to fit, stopping once an earlier card no longer collides — so anchored cards above keep their place. Off mid-document, where the tail is meant to be below the panel and reachable by scrolling. 5 new unit tests (codex-designed values); visually verified the lift engages.

## Same-anchor ordering: oldest on top
Comments sharing an anchor (overlaps, same line) were tie-broken by `randomID()` — arbitrary. They now break ties by **sidecar creation order (oldest first)**, so a stacked cluster reads top-down as a thread. Different-position comments still sort by document position (the anchoring requires it).

828 tests green, build clean. `/code-review` + codex both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
